### PR TITLE
Allow caching at the multiplexer layer to avoid problems with local collections

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npx tsc",
     "build-es2020": "npx tsc -p tsconfig-es2020.json",
     "build-es2015": "npx tsc -p tsconfig-es2015.json",
-    "test": "node --test ./test/index.js",
+    "test": "npm run build && node --test ./test/index.js",
     "test:watch": "node --test --watch --enable-source-maps ./test/index.js",
     "test:watch-only": "node --test --watch --test-only --enable-source-maps ./test/index.js",
     "test:watch-inspect-only": "node --test --watch --test-only --inspect-brk --enable-source-maps ./test/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/cachingChangeObserver.ts
+++ b/src/cachingChangeObserver.ts
@@ -20,8 +20,8 @@ export class CachingChangeObserverImpl<
     ordered,
     cloneDocuments = false,
     clone
-  }: { 
-    ordered: boolean, 
+  }: {
+    ordered: boolean,
     cloneDocuments?: boolean,
     clone?: Clone
   }) {

--- a/src/cachingChangeObserver.ts
+++ b/src/cachingChangeObserver.ts
@@ -1,7 +1,7 @@
 import { applyChanges } from "./diff.js";
 import { OrderedDict } from "./orderedDict.js";
 import { StringableIdMap } from "./stringableIdMap.js";
-import { CachingChangeObserver, OrderedObserveChangesCallbacks, SharedObserveChangesCallbacks, StringObjectWithoutID, Stringable } from "./types.js";
+import { CachingChangeObserver, Clone, OrderedObserveChangesCallbacks, SharedObserveChangesCallbacks, StringObjectWithoutID, Stringable, naiveClone } from "./types.js";
 
 function assertIsOrderedDict<ID extends Stringable, T extends StringObjectWithoutID>(dict: OrderedDict<ID, T> | StringableIdMap<ID, T>): asserts dict is OrderedDict<ID, T> {
 
@@ -13,12 +13,22 @@ export class CachingChangeObserverImpl<
 > implements CachingChangeObserver<ID, T> {
   #docs: OrderedDict<ID, T> | StringableIdMap<ID, T>;
   #ordered: boolean;
+  #cloneDocuments: boolean;
+  #clone: Clone;
 
   constructor({
-    ordered
-  }: { ordered: boolean}) {
+    ordered,
+    cloneDocuments = false,
+    clone
+  }: { 
+    ordered: boolean, 
+    cloneDocuments?: boolean,
+    clone?: Clone
+  }) {
     this.#ordered = ordered;
     this.#docs = ordered ? new OrderedDict<ID, T>() : new StringableIdMap<ID, T>();
+    this.#cloneDocuments = cloneDocuments;
+    this.#clone = clone || naiveClone;
   }
 
   forEach(iterator: (doc: T, id: ID) => void): void {
@@ -31,7 +41,8 @@ export class CachingChangeObserverImpl<
     if (this.#docs.has(id)) {
       throw new Error("This document already exists");
     }
-    this.#docs.set(id, doc);
+    const docToStore = this.#cloneDocuments && doc ? this.#clone(doc) : doc;
+    this.#docs.set(id, docToStore);
   }
 
   addedBefore(id: ID, doc: T, before?: ID): void {
@@ -41,15 +52,16 @@ export class CachingChangeObserverImpl<
     if (before && !this.#docs.has(before)) {
       throw new Error("Adding a document before one that doesn't exist");
     }
+    const docToStore = this.#cloneDocuments && doc ? this.#clone(doc) : doc;
     if (!this.#ordered) {
       // this is an odd situation - but in some cases (e.g., with a limit + sort)
       // the driver may choose to use these callbacks even though they don't care about the order
       // it's weird, but do we really care?
-      this.#docs.set(id, doc);
+      this.#docs.set(id, docToStore);
       return;
     }
     assertIsOrderedDict(this.#docs);
-    this.#docs.add(id, doc, before);
+    this.#docs.add(id, docToStore, before);
   }
 
   changed(id: ID, fields: Partial<T>): void {

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -6,7 +6,9 @@ import { CachingChangeObserver, ObserveChangesCallbackKeys, ObserveChangesCallba
 
 type ObserveMultiplexerOptions = {
   ordered: boolean,
-  onStop?: Function
+  onStop?: Function,
+  cloneDocuments?: boolean,
+  clone?: (doc: any) => any
 }
 
 export class ObserveMultiplexer<
@@ -30,9 +32,15 @@ export class ObserveMultiplexer<
   constructor({
     ordered,
     onStop,
+    cloneDocuments = false,
+    clone
   }: ObserveMultiplexerOptions) {
     this._ordered = ordered;
-    this.#cache = new CachingChangeObserverImpl<ID, T>({ ordered });
+    this.#cache = new CachingChangeObserverImpl<ID, T>({ 
+      ordered, 
+      cloneDocuments,
+      clone
+    });
     this.#ready = new Promise((resolve, reject) => {
       this.#resolve = resolve;
     });

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -65,7 +65,9 @@ export async function observeChanges<T extends { _id: Stringable }>(
         if (driver) {
           driver.stop();
         }
-      }
+      },
+      cloneDocuments: options.cloneDocuments,
+      clone: options.clone
     });
   }
 
@@ -101,7 +103,9 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
   let suppressed = suppressInitial;
   const ordered = observeCallbacksAreOrdered(observeCallbacks);
   const cache = new CachingChangeObserverImpl({
-    ordered
+    ordered,
+    cloneDocuments: false, // We handle cloning separately in the callback implementation
+    clone: _clone
   });
 
   const cloneIfMutating = nonMutatingCallbacks ? <X>(doc: X) => doc : _clone;

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export type ObserveOptions<T extends { _id: Stringable }> = {
   ordered?: boolean,
 
   /**
-   * Set to true if the callbacks (or anything downstream) wont mutate the documents (avoids a clone). You should aim to always set this to true
+   * Set to true if the callbacks (or anything downstream) wont mutate the documents (avoids a clone). You should aim to always set this to true. This option applies to the observer and it's cache, not the multiplexer. For that use `cloneDocuments`
    * @default: false
    */
   nonMutatingCallbacks?: boolean,
@@ -122,6 +122,13 @@ export type ObserveOptions<T extends { _id: Stringable }> = {
    * @default: doc => JSON.parse(JSON.stringify(doc))
    */
   clone?: Clone,
+
+  /**
+   * Enable document cloning in the internal caching layer to prevent document mutation.
+   * When true, documents will be cloned before being stored in the cache.
+   * @default: false
+   */
+  cloneDocuments?: boolean,
 
   /**
    * An "equals" implementation - like EJSON.equals
@@ -263,6 +270,12 @@ export type ObserveChangesObserver<ID extends Stringable, T> = Required<
 > & {
   observes(hookName: keyof ObserveChangesCallbacks<ID, T>): boolean
   // flush(downstream?: boolean): Promise<void>
+}
+
+export type CachingChangeObserverOptions = {
+  ordered: boolean;
+  cloneDocuments?: boolean;
+  clone?: Clone;
 }
 
 export type CachingChangeObserver<ID extends Stringable, T extends StringObjectWithoutID> = ObserveChangesObserver<ID, T> & {

--- a/test/observe.js
+++ b/test/observe.js
@@ -11,10 +11,10 @@ describe("document cloning", () => {
     const data = [{ _id: "testId", field: { nested: "value" } }];
     const collection = new FakeCollection(data);
     const cursor = collection.find({});
-    
+
     // Get reference to the original document
     const originalDoc = data[0];
-    
+
     // Setup observe with cloneDocuments enabled
     const addedMock = mock.fn();
     const handle = await observe(
@@ -23,30 +23,86 @@ describe("document cloning", () => {
       { added: addedMock },
       { cloneDocuments: true, pollingInterval: 5 }
     );
-    
+
     // Wait for initial callbacks
     await setTimeout(10);
-    
+
     // Verify the 'added' callback was called with our document
     assert.strictEqual(addedMock.mock.callCount(), 1, "added callback should be called once");
-    
+
     // Modify the original document
     originalDoc.field.nested = "modified";
-    
+
     // Add another document to trigger polling
     await collection.insertOne({ _id: "testId2", field: "value" });
-    
+
     // Wait for polling to happen
     await setTimeout(10);
-    
+
     // Stop the observer
     handle.stop();
-    
+
     // Get the document as it was passed to the callback
     const addedDoc = addedMock.mock.calls[0].arguments[0];
-    
+
     // Check that the cloned document has the original value, not the modified one
     assert.strictEqual(addedDoc.field.nested, "value", "Document should be a clone with original values");
+  });
+
+  it("should have distinct objects in the changed callback when cloneDocuments is enabled", async () => {
+    // Create collection with an initial document
+    const data = [{ _id: "testId", value: "initial" }];
+    const collection = new FakeCollection(data);
+    const cursor = collection.find({});
+
+    // Capture the original document reference
+    const originalDoc = data[0];
+
+    // Mutable array to store references received in callbacks
+    const capturedDocs = [];
+
+    // Setup a changed callback that captures the oldDoc and newDoc references
+    const changedMock = mock.fn((newDoc, oldDoc) => {
+      capturedDocs.push({ newDoc, oldDoc });
+    });
+
+    // Start observing with cloneDocuments enabled
+    const handle = await observe(
+      cursor,
+      collection,
+      { changed: changedMock },
+      { cloneDocuments: true, pollingInterval: 5 }
+    );
+
+    // Wait for initial setup
+    await setTimeout(10);
+
+    // Update the document
+    originalDoc.value = "updated";
+
+    // Wait for polling to detect the change
+    await setTimeout(15);
+
+    // Verify the callback was called
+    assert.strictEqual(changedMock.mock.callCount(), 1, "changed callback should be called once");
+
+    // Get the captured objects
+    const { newDoc, oldDoc } = capturedDocs[0];
+
+    // Verify the values were passed correctly
+    assert.strictEqual(newDoc.value, "updated", "newDoc has updated value");
+
+    // Test that the objects are distinct (cloned)
+    assert.notStrictEqual(newDoc, oldDoc, "newDoc and oldDoc should be different objects");
+    assert.notStrictEqual(newDoc, originalDoc, "newDoc should not be the original object");
+    assert.notStrictEqual(oldDoc, originalDoc, "oldDoc should not be the original object");
+
+    // Verify that modifying the original again doesn't affect our captured objects
+    originalDoc.value = "modified again";
+    assert.strictEqual(newDoc.value, "updated", "newDoc should not be affected by later modifications");
+
+    // Cleanup
+    handle.stop();
   });
 });
 

--- a/tsconfig-es2015.json
+++ b/tsconfig-es2015.json
@@ -2,9 +2,10 @@
   "include": ["src/*", "src/redis/*"],
   "exclude": ["src/__*"],
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "es2015",
     "module": "ES2015",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "target": "ES2015",
     "declaration": true,
     "useDefineForClassFields": true,
@@ -17,6 +18,12 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "maxNodeModuleJsDepth": 2,
-    "importHelpers": true
+    "resolvePackageJsonImports": true,
+    "importHelpers": true,
+    "paths": {
+      "#asyncQueue": [
+        "./src/clientQueue.js"
+      ]
+    }
   }
 }

--- a/tsconfig-es2020.json
+++ b/tsconfig-es2020.json
@@ -2,9 +2,10 @@
   "include": ["src/*", "src/redis/*"],
   "exclude": ["src/__*"],
   "compilerOptions": {
+    "rootDir": "src",
     "outDir": "es2020",
     "module": "ES2020",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "target": "ES2020",
     "declaration": true,
     "useDefineForClassFields": true,
@@ -14,8 +15,14 @@
     "strictFunctionTypes": true,
     "sourceMap": true,
     "allowJs": true,
+    "resolvePackageJsonImports": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "maxNodeModuleJsDepth": 2
+    "maxNodeModuleJsDepth": 2,
+    "paths": {
+      "#asyncQueue": [
+        "./src/clientQueue.js"
+      ]
+    }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
+    "resolvePackageJsonImports": true,
     "maxNodeModuleJsDepth": 2
   }
 }


### PR DESCRIPTION
When observing a local data source, if you don't clone the documents the observer will observe the literal document stored locally - as such we need to clone, but we don't want to *always* clone, as most of the time we'll be observing a remote data source and an extra clone isn't necessary