### PR TITLE
Small change to typing, larger change to ensure async resources are correctly explicitly destroyed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.14-rc.1",
+  "version": "0.1.14",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -73,7 +73,7 @@
     "@blastjs/minimongo": "^0.1.0",
     "@types/node": "^20.14.9",
     "esbuild": "^0.24.2",
-    "mongo-collection-hooks": "^0.2.13-rc.2",
+    "mongo-collection-hooks": "^0.2.14",
     "mongodb": "^5.9.2",
     "puppeteer": "^24.1.0",
     "typescript": "^5.5.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.13",
+  "version": "0.1.14-rc.1",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -73,7 +73,7 @@
     "@blastjs/minimongo": "^0.1.0",
     "@types/node": "^20.14.9",
     "esbuild": "^0.24.2",
-    "mongo-collection-hooks": "^0.2.3",
+    "mongo-collection-hooks": "^0.2.13-rc.2",
     "mongodb": "^5.9.2",
     "puppeteer": "^24.1.0",
     "typescript": "^5.5.2"

--- a/src/clientQueue.ts
+++ b/src/clientQueue.ts
@@ -99,4 +99,8 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
   async flush(): Promise<void> {
     await this.runTask(() => {});
   }
+
+  destroy(): void {
+    this.#queue = [];
+  }
 }

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -32,12 +32,15 @@ export class ObserveMultiplexer<
   constructor({
     ordered,
     onStop,
-    cloneDocuments = false,
+    // in general, cloneDocuments must always be true
+    // this is not because of add (where cloneDocuments is used) but because of changed, which mutates the fields of the document itself
+    // I don't think there's any situation where we'd want this to be false...
+    cloneDocuments = true,
     clone
   }: ObserveMultiplexerOptions) {
     this._ordered = ordered;
-    this.#cache = new CachingChangeObserverImpl<ID, T>({ 
-      ordered, 
+    this.#cache = new CachingChangeObserverImpl<ID, T>({
+      ordered,
       cloneDocuments,
       clone
     });
@@ -112,6 +115,7 @@ export class ObserveMultiplexer<
       throw new Error("How'd we stop when we aren't ready?");
     }
     this.#stopped = true;
+    this.#queue.destroy();
     this.#onStop?.();
   }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -4,4 +4,5 @@ export interface AsynchronousQueue {
   _run(): void;
   _scheduleRun(): void;
   flush(): Promise<void>;
+  destroy(): void;
 }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -637,5 +637,6 @@ export class RedisObserverDriver<
 
   stop(): void {
     this.#manager.detach<T, SortT, FilterT>(this);
+    this.#queue.destroy();
   }
 }


### PR DESCRIPTION
This PR does two mostly non-functional things:

1. fixes the typing for the applyRedis function, such that it now understands the additional generic argument of HookedCollection
2. improves the usage of async resources, ensuring we emitDestroy when they are