### PR TITLE
Ensure observe awaits async callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/clientQueue.ts
+++ b/src/clientQueue.ts
@@ -34,10 +34,10 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
   constructor(_bindTasksToQueueAsyncResource = false, errorHandler: (error: any) => void = console.warn) {
     this.#errorHandler = errorHandler;
   }
-  async runTask<F extends any>(task: () => F | Promise<F>): Promise<F> {
+  async runTask<F extends any>(task: () => F | Promise<F>, name?: string): Promise<F> {
     return new Promise((resolve, reject) => {
       const taskHandle = new TaskHandle({
-        name: task.name,
+        name: name || task.name,
         task,
         resolve,
         reject
@@ -47,9 +47,9 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
     });
   }
 
-  queueTask(task: Function) {
+  queueTask(task: Function, name?: string) {
     this.#queue.push(new TaskHandle({
-      name: task.name,
+      name: name || task.name,
       task
     }));
     this._scheduleRun();
@@ -97,7 +97,7 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
   }
 
   async flush(): Promise<void> {
-    await this.runTask(() => {});
+    await this.runTask(() => {}, "internalFlush");
   }
 
   destroy(): void {

--- a/src/handle.ts
+++ b/src/handle.ts
@@ -67,41 +67,41 @@ export class ObserveHandleImpl<
     return !!this.#callbacks[hookName];
   }
 
-  added(_id: ID, doc: T) {
-    this.#maybeAsyncResource.runInAsyncScope(() => {
+  async added(_id: ID, doc: T) {
+    await this.#maybeAsyncResource.runInAsyncScope(() => {
       if (this.#callbacks.added) {
-        this.#callbacks.added(_id, this.nonMutatingCallbacks ? doc : this.#clone(doc));
+        return this.#callbacks.added(_id, this.nonMutatingCallbacks ? doc : this.#clone(doc));
       }
     });
   }
-  addedBefore(_id: ID, doc: T, before?: ID) {
-    this.#maybeAsyncResource.runInAsyncScope(() => {
+  async addedBefore(_id: ID, doc: T, before?: ID) {
+    await this.#maybeAsyncResource.runInAsyncScope(() => {
       if (this.#callbacks.addedBefore) {
-        this.#callbacks.addedBefore(_id, this.nonMutatingCallbacks ? doc : this.#clone(doc), before);
+        return this.#callbacks.addedBefore(_id, this.nonMutatingCallbacks ? doc : this.#clone(doc), before);
       }
     });
   }
 
-  movedBefore(_id: ID, before: ID | undefined) {
-    this.#maybeAsyncResource.runInAsyncScope(() => {
+  async movedBefore(_id: ID, before: ID | undefined) {
+    await this.#maybeAsyncResource.runInAsyncScope(() => {
       if (this.#callbacks.movedBefore) {
-        this.#callbacks.movedBefore(_id, before);
+        return this.#callbacks.movedBefore(_id, before);
       }
     });
   }
 
-  changed(_id: ID, fields: Partial<T>) {
-    this.#maybeAsyncResource.runInAsyncScope(() => {
+  async changed(_id: ID, fields: Partial<T>) {
+    await this.#maybeAsyncResource.runInAsyncScope(() => {
       if (this.#callbacks.changed) {
-        this.#callbacks.changed(_id, this.nonMutatingCallbacks ? fields : this.#clone(fields));
+        return this.#callbacks.changed(_id, this.nonMutatingCallbacks ? fields : this.#clone(fields));
       }
     });
   }
 
-  removed(_id: ID) {
-    this.#maybeAsyncResource.runInAsyncScope(() => {
+  async removed(_id: ID) {
+    await this.#maybeAsyncResource.runInAsyncScope(() => {
       if (this.#callbacks.removed) {
-        this.#callbacks.removed(_id);
+        return this.#callbacks.removed(_id);
       }
     });
   }

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -69,6 +69,9 @@ export async function observeChanges<T extends { _id: Stringable }>(
       cloneDocuments: options.cloneDocuments,
       clone: options.clone
     });
+
+    // @ts-expect-error we're setting a private property to make testing a bit easier
+    multiplexer._driver = driver;
   }
 
   observerMultiplexers.set(id, multiplexer as unknown as ObserveMultiplexer<T["_id"]>);
@@ -129,7 +132,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         const beforeDoc = before && transform(cloneIfMutating(cache.get(before)));
 
         if (observeCallbacks.addedAt) {
-          observeCallbacks.addedAt(
+          return observeCallbacks.addedAt(
             doc,
             indices
               ? before
@@ -140,7 +143,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
           );
         }
         else if (observeCallbacks.added) {
-          observeCallbacks.added(doc);
+          return observeCallbacks.added(doc);
         }
       },
       changed(id, fields) {
@@ -159,14 +162,14 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         applyChanges(doc, fields);
 
         if (observeCallbacks.changedAt) {
-          observeCallbacks.changedAt(
+          return observeCallbacks.changedAt(
             transform(doc),
             oldDoc,
             indices ? cache.indexOf(id) : -1
           );
         }
         else if (observeCallbacks.changed) {
-          observeCallbacks.changed(transform(doc), oldDoc);
+          return observeCallbacks.changed(transform(doc), oldDoc);
         }
       },
       movedBefore(id, before) {
@@ -189,7 +192,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
           --to;
         }
 
-        observeCallbacks.movedTo(
+        return observeCallbacks.movedTo(
           transform(cloneIfMutating(cache.get(id))),
           from,
           to,
@@ -208,10 +211,10 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         cache.removed(id);
 
         if (observeCallbacks.removedAt) {
-          observeCallbacks.removedAt(doc, index);
+          return observeCallbacks.removedAt(doc, index);
         }
         else if (observeCallbacks.removed) {
-          observeCallbacks.removed(doc);
+          return observeCallbacks.removed(doc);
         }
       },
     };
@@ -223,7 +226,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         }
         cache.added(id, { _id: id, ...fields });
         if (observeCallbacks.added) {
-          observeCallbacks.added(transform({ ...fields, _id: id }));
+          return observeCallbacks.added(transform({ ...fields, _id: id }));
         }
       },
       changed(id, fields) {
@@ -238,7 +241,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
 
           applyChanges(doc, fields);
 
-          observeCallbacks.changed(
+          return observeCallbacks.changed(
             transform(cloneIfMutating(doc)),
             oldDocCloned
           );
@@ -248,7 +251,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         if (observeCallbacks.removed) {
           const doc = cache.get(id);
           cache.removed(id);
-          observeCallbacks.removed(transform(doc));
+          return observeCallbacks.removed(transform(doc));
         }
       },
     };

--- a/src/pollingDriver.ts
+++ b/src/pollingDriver.ts
@@ -84,7 +84,6 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
 
   // this member is public so that certain types (e.g., local) can inherit from it and use it
   async _poll() {
-    // TODO: pause polling
     if (!this.#multiplexer) {
       throw new Error("Can't be missing a multiplexer");
     }

--- a/src/serverQueue.ts
+++ b/src/serverQueue.ts
@@ -54,10 +54,10 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
     this.#errorHandler = errorHandler;
     this.#bindTasksToQueueAsyncResource = bindTasksToQueueAsyncResource;
   }
-  async runTask<F extends any>(task: () => F | Promise<F>): Promise<F> {
+  async runTask<F extends any>(task: () => F | Promise<F>, name?: string): Promise<F> {
     return new Promise((resolve, reject) => {
       const taskHandle = new TaskHandle({
-        name: task.name,
+        name: name || task.name,
         task,
         resolve,
         reject
@@ -67,9 +67,9 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
     });
   }
 
-  queueTask(task: Function) {
+  queueTask(task: Function, name?: string) {
     this.#queue.push(new TaskHandle({
-      name: task.name,
+      name: name || task.name,
       task
     }));
     this._scheduleRun();
@@ -125,7 +125,7 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
   }
 
   async flush(): Promise<void> {
-    await this.runTask(() => {});
+    await this.runTask(() => {}, "internalFlush");
   }
 
   destroy(): void {

--- a/test/observeChanges.js
+++ b/test/observeChanges.js
@@ -211,4 +211,115 @@ describe("ordered observeChanges", () => {
 
     assert.strictEqual(removedMock.mock.callCount(), 1);
   });
+
+  describe("async callbacks are processed in order", () => {
+
+    // This test is a bit tricky, the observe driver generally can't cause events out of order because the driver uses the queue
+    // additionally, the driver can choose (and the polling driver does) to wait for the multiplexer to flush before it polls again
+    // this means the test needs to get all the changes in a single poll
+    // but the order in which the driver "observes" those events is up to it - e.g., should the change or the add come first? Who knows?
+    // but we're specifically trying to test that the callbacks are processed in a known order when we cause one to be delayed.
+    // maybe the multiplexer is a better place to test this? But part of the goal is to test that the ultimate observe call doesn't mess things up
+    // this is less relevant to observeChanges
+    // broadly this "works" because if the multiplexer isn't awaiting the callbacks correctly, it's queue will flush early
+
+    const combos = [
+      {
+        ordered: false,
+        data: [{ _id: "z" }],
+        firstEvent: "added",
+        firstAction: collection => collection.insertOne({ _id: "a" }),
+        secondEvent: "changed",
+        secondAction: collection => collection.updateOne({ _id: "z" }, { $set: { value: "hello" } })
+      },
+      {
+        ordered: false,
+        data: [{ _id: "z" }],
+        firstEvent: "added",
+        firstAction: collection => collection.insertOne({ _id: "a" }),
+        secondEvent: "removed",
+        secondAction: collection => collection.deleteOne({ _id: "z" })
+      },
+      {
+        ordered: false,
+        data: [{ _id: "test" }],
+        firstEvent: "changed",
+        firstAction: collection => collection.updateOne({ _id: "test" }, { $set: { value: "hello" } }),
+        secondEvent: "added",
+        secondAction: collection => collection.insertOne({ _id: "newTest" })
+      },
+      {
+        ordered: false,
+        data: [{ _id: "test" }],
+        firstEvent: "changed",
+        firstAction: collection => collection.updateOne({ _id: "test" }, { $set: { value: "hello" } }),
+        secondEvent: "removed",
+        secondAction: collection => collection.deleteOne({ _id: "test" })
+      },
+      {
+        ordered: false,
+        data: [{ _id: "test" }],
+        firstEvent: "removed",
+        firstAction: collection => collection.deleteOne({ _id: "test" }),
+        secondEvent: "added",
+        secondAction: collection => collection.insertOne({ _id: "newTest" })
+      },
+      {
+        ordered: false,
+        data: [{ _id: "test" }, { _id: "test2"}],
+        firstEvent: "removed",
+        firstAction: collection => collection.deleteOne({ _id: "test" }),
+        secondEvent: "changed",
+        secondAction: collection => collection.updateOne({ _id: "test2" }, { $set: { value: "hello" } })
+      }
+    ];
+
+    combos.forEach(({
+      ordered,
+      data,
+      firstEvent,
+      firstAction,
+      secondEvent,
+      secondAction
+    }) => {
+      it(`async ${firstEvent} -> ${secondEvent} callbacks are processed in order`, async () => {
+        const collection = new FakeCollection(data);
+        const cursor = collection.find({});
+
+        const events = [];
+        let isInitial = true;
+        const handle = await observeChanges(
+          cursor,
+          collection,
+          {
+            [firstEvent]: async () => {
+              if (!isInitial) {
+                await setTimeout(100);
+                events.push(firstEvent);
+              }
+            },
+            [secondEvent]: async () => {
+              if (!isInitial) {
+                events.push(secondEvent);
+              }
+            }
+          },
+          {
+            ordered,
+            pollingInterval: 10
+          }
+        );
+        isInitial = false;
+        await firstAction(collection);
+        await setTimeout(20);
+        await secondAction(collection);
+        await setTimeout(200);
+
+        await handle._multiplexer.flush();
+        // handle.stop();
+
+        assert.deepEqual(events, [firstEvent, secondEvent], "events should be in order");
+      });
+    });
+  });
 });


### PR DESCRIPTION
Currently, neither `observe` nor `observeChanges` will correctly await async callbacks. This resolves that problem and tests some combinations (testing ordered operations is a bit tedious)

Secondarily, it adds the ability to specify names to the async queue - this is primarily for debugging