### PR TITLE
Fix Deadlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/clientQueue.ts
+++ b/src/clientQueue.ts
@@ -5,7 +5,8 @@ type TaskHandleOptions = {
   resolve?: (result: any) => void,
   reject?: (error: any) => void,
   name?: string,
-  task?: Function
+  task?: Function,
+  mustRun?: boolean
 };
 
 class TaskHandle {
@@ -13,16 +14,22 @@ class TaskHandle {
   reject: ((error: any) => void) | undefined;
   name: string | undefined;;
   task: Function | undefined;
+  #mustRun: boolean = false;
   constructor({
     resolve,
     reject,
     name,
-    task
+    task,
+    mustRun = false
   }: TaskHandleOptions) {
     this.name = name;
     this.task = task;
     this.resolve = resolve;
     this.reject = reject;
+  }
+
+  get mustRun() {
+    return this.#mustRun;
   }
 }
 
@@ -40,7 +47,8 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
         name: name || task.name,
         task,
         resolve,
-        reject
+        reject,
+        mustRun: true
       });
       this.#queue.push(taskHandle);
       this._scheduleRun();
@@ -100,7 +108,24 @@ export class AsynchronousQueue implements AsynchronousQueueInterface {
     await this.runTask(() => {}, "internalFlush");
   }
 
+
+  drainAndDestroy(): boolean {
+    const hasFlushTasks = this.#queue.some((task) => task.mustRun);
+    if (hasFlushTasks) {
+      const remainingTasks = this.#queue.filter((task) => task.mustRun);
+      this.#queue = remainingTasks;
+      this.queueTask(() => this.destroy(), "destroy");
+      return false;
+    }
+    this.destroy();
+    return true;
+  }
+
   destroy(): void {
+    this.#queue.forEach((task) => {
+      // this ensures we can't deadlock if we get it wrong - but in general it'd be bad to throw if we don't have to
+      task.reject?.(new Error("AsynchronousQueue destroyed before task could run"));
+    });
     this.#queue = [];
   }
 }

--- a/src/clientQueue.ts
+++ b/src/clientQueue.ts
@@ -26,6 +26,7 @@ class TaskHandle {
     this.task = task;
     this.resolve = resolve;
     this.reject = reject;
+    this.#mustRun = mustRun;
   }
 
   get mustRun() {

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -118,7 +118,12 @@ export class ObserveMultiplexer<
       throw new Error("How'd we stop when we aren't ready?");
     }
     this.#stopped = true;
-    this.#queue.destroy();
+    // if a handle itself calls destroy, we can end up in a bad situation - specifically:
+    // if we have behaviour (e.g., optimistic UX) that requires flushing the queue as part of the DB operation
+    // and the callback calls `handle.stop()` and it's the last handle, we either deadlock or the flush task throws an error (destroy enforces the latter)
+    // but this would be bad - as the original DB operation would record the lack of flush as an error
+    // so instead, here we check to see if there are any flush tasks pending, drain the queue of everything else and queue a destroy task.
+    this.#queue.drainAndDestroy();
     this.#onStop?.();
   }
 

--- a/src/pollingDriver.ts
+++ b/src/pollingDriver.ts
@@ -11,6 +11,7 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
   #pollingInterval: NodeJS.Timeout | undefined;
   #pollingIntervalTime = DEFAULT_POLLING_INTERVAL;
   #ordered: boolean;
+  #stopped: boolean = false;
   #multiplexer: ObserveMultiplexerInterface<T["_id"], Omit<T, "_id">> | undefined;
   #options: ObserveOptions<T>;
   #running: boolean = false;
@@ -92,10 +93,20 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
       const { _id, ...rest } = doc;
       newDocs.set(_id, rest);
     });
+    if (this.#stopped) {
+      return;
+    }
     await this.#multiplexer.flush();
+    if (this.#stopped) {
+      return;
+    }
     if (this.#ordered) {
+      const docs = (await this.#multiplexer.getDocs()).entries();
+      if (this.#stopped) {
+        return;
+      }
       diffQueryOrderedChanges<T>(
-        Array.from((await this.#multiplexer.getDocs()).entries()).map(([_id, doc]) => ({ _id, ...doc }) as T),
+        Array.from(docs).map(([_id, doc]) => ({ _id, ...doc }) as T),
         Array.from(newDocs.entries()).map(([_id, doc]) => ({ _id, ...doc }) as T),
         this.#multiplexer,
         {
@@ -105,8 +116,12 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
       );
     }
     else {
+      const docs = await this.#multiplexer.getDocs() as StringableIdMap<T["_id"], T>;
+      if (this.#stopped) {
+        return;
+      }
       diffQueryUnorderedChanges<T["_id"], T>(
-        await this.#multiplexer.getDocs() as StringableIdMap<T["_id"], T>,
+        docs,
         newDocs as StringableIdMap<T["_id"], T>,
         this.#multiplexer,
         {
@@ -115,10 +130,14 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
         }
       );
     }
+    if (this.#stopped) {
+      return;
+    }
     await this.#multiplexer.flush();
   }
 
   stop(): void {
+    this.#stopped = true;
     if (this.#pollingInterval) {
       clearInterval(this.#pollingInterval);
     }

--- a/src/queueStoppedError.ts
+++ b/src/queueStoppedError.ts
@@ -1,0 +1,7 @@
+export class QueueStoppedError extends Error {
+  isQueueStoppedError = true;
+  constructor(message: string = "This queue has been stopped") {
+    super(message);
+    this.name = "QueueStoppedError";
+  }
+}

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -82,7 +82,7 @@ export class RedisObserverDriver<
   #sortDocs: OrderedDict<T["_id"], SortT> | undefined;
   #strictRelevance: boolean;
   #multiplexer: ObserveMultiplexerInterface<T["_id"], ET> | undefined;
-
+  #stopped: boolean = false;
   #channels: string[];
   #mapTransform: (projection: Document) => T = doc => doc as T;
 
@@ -168,6 +168,9 @@ export class RedisObserverDriver<
 
   process(channel: string, message: RedisMessage<T & SortT>, options?: { optimistic?: boolean }): void | Promise<void> {
     const runner = options?.optimistic ? this.#queue.runTask.bind(this.#queue) : this.#queue.queueTask.bind(this.#queue);
+    if (this.#stopped) {
+      return;
+    }
     return runner(async () => {
       if (this.#strategy === Strategy.DEDICATED_CHANNELS) {
         await this.#processDedicatedChannelMessage(message);
@@ -179,6 +182,9 @@ export class RedisObserverDriver<
         await this.#processDefaultMessage(message);
       }
       if (options?.optimistic) {
+        if (this.#stopped) {
+          return;
+        }
         await this.#multiplexer?.flush(true);
       }
     });
@@ -265,8 +271,14 @@ export class RedisObserverDriver<
     if (message[RedisPipe.EVENT] === Events.INSERT) {
       const doc = message[RedisPipe.DOC];
       if (!await this.#has(doc._id) && this.#isDocEligible(doc)) {
+        if (this.#stopped) {
+          return;
+        }
         this.#multiplexer.added(doc._id, this.#projectionFnWithMapWithoutId(doc));
       }
+      return;
+    }
+    if (this.#stopped) {
       return;
     }
     if (message[RedisPipe.EVENT] === Events.UPDATE) {
@@ -274,7 +286,13 @@ export class RedisObserverDriver<
       if (this.#isDocEligible(doc)) {
         const projectedDoc = this.#projectionFnWithMapWithoutId(doc);
         if (await this.#has(doc._id)) {
+          if (this.#stopped) {
+            return;
+          }
           const original = await this.#get(doc._id);
+          if (this.#stopped) {
+            return;
+          }
           if (!original) {
             throw new Error("somehow between #has and #get we lots the doc");
           }
@@ -287,10 +305,16 @@ export class RedisObserverDriver<
           }
         }
         else {
+          if (this.#stopped) {
+            return;
+          }
           this.#multiplexer.added(doc._id, projectedDoc);
         }
       }
       else if (await this.#has(doc._id)){
+        if (this.#stopped) {
+          return;
+        }
         this.#multiplexer.removed(doc._id);
       }
       return;
@@ -316,6 +340,9 @@ export class RedisObserverDriver<
       newDocs.add(doc._id, {});
     });
 
+    if (this.#stopped) {
+      return;
+    }
     diffQueryOrderedChanges(
       [...this.#sortDocs.keys()].map(id => ({ _id: id })),
       [...newDocs.keys()].map(id => ({ _id: id })),
@@ -376,6 +403,9 @@ export class RedisObserverDriver<
   }
 
   #handleLimitSortMaybeAdd = async (message: RedisMessage<T & SortT>) => {
+    if (this.#stopped) {
+      return;
+    }
     const options = this.#cursor.cursorDescription.options;
     const doc = message[RedisPipe.DOC] as T & SortT;
     if (!this.#sortDocs) {
@@ -637,6 +667,7 @@ export class RedisObserverDriver<
 
   stop(): void {
     this.#manager.detach<T, SortT, FilterT>(this);
-    this.#queue.destroy();
+    this.#stopped = true;
+    this.#queue.drainAndDestroy();
   }
 }

--- a/src/serverQueue.ts
+++ b/src/serverQueue.ts
@@ -1,12 +1,14 @@
 import { AsyncResource } from "async_hooks";
 import { AsynchronousQueue as AsynchronousQueueInterface } from "./queue.js"
+import { QueueStoppedError } from "./queueStoppedError.js";
 
 
 type TaskHandleOptions = {
   resolve?: (result: any) => void,
   reject?: (error: any) => void,
   name?: string,
-  task?: Function
+  task?: Function,
+  mustRun?: boolean
 };
 
 class TaskHandle extends AsyncResource {
@@ -14,16 +16,19 @@ class TaskHandle extends AsyncResource {
   reject: ((error: any) => void) | undefined;
   name: string | undefined;;
   task: Function | undefined;
+  #mustRun: boolean;
   #destroyed: boolean = false;
   constructor({
     resolve,
     reject,
     name,
-    task
+    task,
+    mustRun = false
   }: TaskHandleOptions) {
     super("TaskHandle");
     this.name = name;
     this.task = task;
+    this.#mustRun = mustRun;
     this.resolve = (arg) => {
       this.destroy();
       resolve?.(arg);
@@ -32,6 +37,10 @@ class TaskHandle extends AsyncResource {
       this.destroy();
       reject?.(err);
     }
+  }
+
+  get mustRun() {
+    return this.#mustRun;
   }
 
   destroy() {
@@ -46,6 +55,7 @@ class TaskHandle extends AsyncResource {
 export class AsynchronousQueue extends AsyncResource implements AsynchronousQueueInterface {
   #queue: TaskHandle[] = [];
   #running: boolean = false;
+  #destroyed: boolean = false;
   #bindTasksToQueueAsyncResource: boolean = false;
   #errorHandler: (error: any) => void;
 
@@ -55,12 +65,16 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
     this.#bindTasksToQueueAsyncResource = bindTasksToQueueAsyncResource;
   }
   async runTask<F extends any>(task: () => F | Promise<F>, name?: string): Promise<F> {
+    if (this.#destroyed) {
+      throw new QueueStoppedError();
+    }
     return new Promise((resolve, reject) => {
       const taskHandle = new TaskHandle({
         name: name || task.name,
         task,
         resolve,
-        reject
+        reject,
+        mustRun: true
       });
       this.#queue.push(taskHandle);
       this._scheduleRun();
@@ -68,6 +82,9 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
   }
 
   queueTask(task: Function, name?: string) {
+    if (this.#destroyed) {
+      throw new QueueStoppedError();
+    }
     this.#queue.push(new TaskHandle({
       name: name || task.name,
       task
@@ -128,8 +145,24 @@ export class AsynchronousQueue extends AsyncResource implements AsynchronousQueu
     await this.runTask(() => {}, "internalFlush");
   }
 
+  drainAndDestroy(): boolean {
+    const hasFlushTasks = this.#queue.some((task) => task.mustRun);
+    if (hasFlushTasks) {
+      const remainingTasks = this.#queue.filter((task) => task.mustRun);
+      this.#queue = remainingTasks;
+      this.queueTask(() => this.destroy(), "destroy");
+      this.#destroyed = true;
+      return false;
+    }
+    this.destroy();
+    return true;
+  }
+
   destroy(): void {
+    this.#destroyed = true;
     this.#queue.forEach((task) => {
+      // this ensures we can't deadlock if we get it wrong - but in general it'd be bad to throw if we don't have to
+      task.reject?.(new Error("AsynchronousQueue destroyed before task could run"));
       task.destroy();
     });
     this.#queue = [];

--- a/test/multiplexer.js
+++ b/test/multiplexer.js
@@ -23,6 +23,19 @@ class DelayedPollingDriver extends PollingDriver {
   }
 }
 
+class NoopDriver extends PollingDriver {
+  constructor(cursor, collection, options) {
+    super(cursor, collection, { ...options, pollingInterval: 1000000 });
+  }
+  /**
+   *
+   * @param {ObserveMultiplexer} multiplexer
+   */
+  async init(multiplexer) {
+    multiplexer.ready();
+  }
+}
+
 
 describe("multiplexer", () => {
   it("should add the initial items to the first handle", async () => {
@@ -179,5 +192,37 @@ describe("multiplexer", () => {
       }
     );
     assert.notEqual(handle2._multiplexer, handle3._multiplexer, "Should NOT have the same multiplexer");
+  });
+
+  it("Shouldn't deadlock", async () => {
+    const collection = new FakeCollection([{ _id: "test" }]);
+    const cursor = collection.find({});
+    const handle = await observeChanges(cursor, collection, {
+      changed: (id, fields) => {
+        handle.stop();
+      }
+    }, { driverClass: NoopDriver });
+
+    /**
+     * @type {ObserveMultiplexer}
+     */
+    const multiplexer = handle._multiplexer;
+    multiplexer.added("test", {});
+    await multiplexer.flush();
+
+    const oldUpdateOne = collection.updateOne;
+    collection.updateOne = async function updateOne({ _id }, mutator) {
+      const result = await oldUpdateOne.call(this, { _id }, mutator);
+      multiplexer.changed(_id, { a: 1 });
+      await multiplexer.flush();
+      return result;
+    };
+
+    const result = await Promise.race([
+      setTimeout(5000).then(() => false),
+      collection.updateOne({ _id: "test" }, { $set: { a: 1 } }).then(() => true)
+    ]);
+
+    assert.strictEqual(result, true, "Should have completed the update without deadlocking");
   });
 });


### PR DESCRIPTION
If you have code like this:

```
let handle = await observeChanges(..., {
  changed() {
    handle.stop();
  }
}

await handle._multiplexer.flush();
```

Which is not as outlandish as it seems, the flush will deadlock. Now, the flush will be allowed to drain before the queue is destroyed, which will also throw if you try to add anything to it. This requires a reasonable amount of guarding