### PR TITLE
Swallow QueueStoppedError to avoid race conditions interrupting DB operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -42,7 +42,17 @@ export async function handleRemove(
           [RedisPipe.DOC]: { _id },
           [RedisPipe.UID]: publishOptions.uid
         };
-        await publishOptions.emit(channel, event, options);
+        try {
+          await publishOptions.emit(channel, event, options);
+        }
+        catch (err: any) {
+          if (err?.name?.includes('QueueStoppedError')) {
+            // swallow - this is just a race condition
+          }
+          else {
+            throw err;
+          }
+        }
       }));
     }));
   }
@@ -66,7 +76,17 @@ export async function handleUpdate(
           [RedisPipe.FIELDS]: fields,
           [RedisPipe.UID]: publishOptions.uid
         };
-        await publishOptions.emit(channel, event, options);
+        try {
+          await publishOptions.emit(channel, event, options);
+        }
+        catch (err: any) {
+          if (err?.name?.includes('QueueStoppedError')) {
+            // swallow - this is just a race condition
+          }
+          else {
+            throw err;
+          }
+        }
       }));
     }));
   }
@@ -89,7 +109,17 @@ export async function handleInserts(
           [RedisPipe.DOC]: { _id: id },
           [RedisPipe.UID]: publishOptions.uid
         };
-        await publishOptions.emit(channel, event, options);
+        try {
+          await publishOptions.emit(channel, event, options);
+        }
+        catch (err: any) {
+          if (err?.name?.includes('QueueStoppedError')) {
+            // swallow - this is just a race condition
+          }
+          else {
+            throw err;
+          }
+        }
       }));
     }));
   }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -172,6 +172,9 @@ export class RedisObserverDriver<
       return;
     }
     return runner(async () => {
+      if (this.#stopped) {
+        return;
+      }
       if (this.#strategy === Strategy.DEDICATED_CHANNELS) {
         await this.#processDedicatedChannelMessage(message);
       }


### PR DESCRIPTION
It's quite hard to catch every case of `QueueStoppedError` - every `await` in subscriber.ts needs to be followed by a check for `this.#stopped` - I guess in theory we could queue the stop, but then stop would become async and need to be awaited. Perhaps down the road I will do that.