### PR TITLE
Ensure requery clones the cursor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -79,6 +79,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "mongo-collection-helpers": "^1.0.13"
+    "mongo-collection-helpers": "^1.0.14"
   }
 }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -339,7 +339,10 @@ export class RedisObserverDriver<
       throw new Error("Can't requery without a local ordered dict");
     }
     const newDocs = new OrderedDict<T["_id"], {}>();
-    await this.#cursor.project<{ _id: T["_id"] }>({ _id: 1 }).forEach((doc) => {
+    // the cursor has already been initted, so we must clone it in order to pull just the ID off of it.
+    // But we do want just the ID because (for better or worse) the `addedBefore` handler below will fetch the full document
+    // we don't fetch the full document here because we only need to fetch new documents - which in general will be a small subset
+    await this.#cursor.clone().project<{ _id: T["_id"] }>({ _id: 1 }).forEach((doc) => {
       newDocs.add(doc._id, {});
     });
 

--- a/test/observe.js
+++ b/test/observe.js
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { FakeCollection } from "mongo-collection-helpers/testHelpers";
-import { beforeEach, describe, it, mock } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert";
 import { setTimeout } from "node:timers/promises";
 import { observe } from "../lib/observe.js";

--- a/test/observe.js
+++ b/test/observe.js
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import { FakeCollection } from "mongo-collection-helpers/testHelpers";
-import { describe, it, mock } from "node:test";
+import { beforeEach, describe, it, mock } from "node:test";
 import assert from "node:assert";
 import { setTimeout } from "node:timers/promises";
 import { observe } from "../lib/observe.js";
@@ -386,7 +386,7 @@ describe("unordered observe", () => {
         await setTimeout(200);
 
         await handle._multiplexer.flush();
-        // handle.stop();
+        handle.stop();
 
         assert.deepEqual(events, [firstEvent, secondEvent], "events should be in order");
       });
@@ -539,5 +539,57 @@ describe("ordered observe", () => {
     handle.stop();
 
     assert.strictEqual(removedMock.mock.callCount(), 1);
+  });
+});
+
+
+describe("observe with sort and limit", () => {
+  function init() {
+    const data = [
+      { _id: "test1", number: 1 },
+      { _id: "test2", number: 2 },
+      { _id: "test3", number: 3 },
+      { _id: "test4", number: 4 },
+      { _id: "test5", number: 5 }
+    ];
+    const collection = new FakeCollection(data);
+
+    return { data, collection };
+  }
+  it("Should receive correct added callbacks", async () => {
+    const { collection } = init();
+    const cursor = collection.find({}, { sort: { number: -1 }, limit: 3 });
+    const addedMock = mock.fn();
+    const handle = await observe(
+      cursor,
+      collection,
+      {
+        addedAt: addedMock,
+        _no_indices: true
+      },
+      {
+        ordered: true,
+        pollingInterval: 5
+      }
+    );
+
+    await setTimeout(10);
+
+    assert.strictEqual(addedMock.mock.callCount(), 3, "should have seen 3 adds");
+    assert.deepEqual(
+      addedMock.mock.calls.map(call => call.arguments[0]._id),
+      ["test5", "test4", "test3"],
+      "should have received the top 3 documents sorted by number desc"
+    );
+
+    await collection.insertOne({ _id: "test6", number: 6 });
+    await setTimeout(20);
+    assert.strictEqual(addedMock.mock.callCount(), 4, "should have seen another add for the new top document");
+    assert.deepEqual(
+      addedMock.mock.calls[3].arguments[0],
+      { _id: "test6", number: 6 },
+      "should have received the new top document"
+    );
+    handle.stop();
   });
 });

--- a/test/observeChanges.js
+++ b/test/observeChanges.js
@@ -316,7 +316,7 @@ describe("ordered observeChanges", () => {
         await setTimeout(200);
 
         await handle._multiplexer.flush();
-        // handle.stop();
+        handle.stop();
 
         assert.deepEqual(events, [firstEvent, secondEvent], "events should be in order");
       });


### PR DESCRIPTION
The changes made [here](https://github.com/znewsham/mongo-collection-helpers/pull/3) exposed the problem - calling `.project` on an executed mongo cursor throws an error - for `#requery` we need to be able to re-query the cursor to get new documents when one is added/removed. 

The test changes are mostly irrelevant - since the "bug" was the lack of clone and our fake cursor didn't throw when it should have. 