### PR TITLE
Skip null/undefined ids in extractIdsFromSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "observe-mongo",
   "type": "module",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "description": "A set of functions to allow you to observe arbitrary mongo cursors with minimal modifications",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -34,8 +34,13 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
       const type = getType(idField);
       if (type === OperationType.FILTER) {
         const idFilter = idField as FilterOperators<Stringable>;
-        idFilter.$in?.forEach(id => ids.add(id));
-        if (idFilter.$eq) {
+        // Skip null/undefined - stringId would crash trying to read `_bsontype` on them.
+        idFilter.$in?.forEach(id => {
+          if (id !== null && id !== undefined) {
+            ids.add(id);
+          }
+        });
+        if (idFilter.$eq !== null && idFilter.$eq !== undefined) {
           ids.add(idFilter.$eq);
         }
       }

--- a/test/redis.js
+++ b/test/redis.js
@@ -509,6 +509,28 @@ describe("Redis Observer", () => {
       await subscriber._queue.flush();
       assert.strictEqual(addedMock.mock.callCount(), 1, "Should not have called added again");
     });
+    it("should skip null/undefined ids in $in without throwing", async () => {
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const cursor = collection.find({ _id: { $in: [undefined, null, "test"] } }, {});
+
+      const subscriber = new RedisObserverDriver(
+        cursor,
+        collection,
+        {
+          ordered: false,
+          manager: subscriptionManager,
+          Matcher: Minimongo.Matcher
+        }
+      );
+
+      assert.deepStrictEqual(
+        subscriber.channels,
+        [`${collectionName}::test`],
+        "should only subscribe to channels for non-null, non-undefined ids"
+      );
+    });
   });
   describe("limit sort processor", () => {
     // insert test cases


### PR DESCRIPTION
## Summary
- A filter like `{ _id: { $in: [undefined, "a"] } }` (or `null`) picks the `DEDICATED_CHANNELS` strategy, then `#getChannels` calls `stringId(undefined)` → `jsonable(undefined)` and crashes on `undefined._bsontype`.
- Skip `null`/`undefined` values in both `$in` and `$eq` inside `extractIdsFromSelector` so channel construction is safe. Other primitives (string/number/boolean/etc.) auto-box on property access, so `null`/`undefined` are the only values that cause the throw.

## Test plan
- [x] New regression test in `test/redis.js` constructs a `RedisObserverDriver` with `{ _id: { $in: [undefined, null, "test"] } }`. Without the fix this throws `TypeError: Cannot read properties of undefined (reading '_bsontype')` from `jsonable`; with the fix `subscriber.channels` is exactly `["redisServerTests::test"]`.
- [x] `npm test` — all 116 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)