### PR TITLE
Thanks typescript

### DIFF
--- a/src/cachingChangeObserver.ts
+++ b/src/cachingChangeObserver.ts
@@ -37,6 +37,12 @@ export class CachingChangeObserverImpl<
     });
   }
 
+  async forEachAsync(iterator: (doc: T, id: ID) => void | Promise<void>): Promise<void> {
+    for (const [id, doc] of this.#docs) {
+      await iterator(doc, id);
+    }
+  }
+
   added(id: ID, doc: T): void {
     if (this.#docs.has(id)) {
       throw new Error("This document already exists");

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -109,7 +109,7 @@ export function diffQueryUnorderedChanges<ID extends Stringable, T>(
 }
 
 
-export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
+export async function diffQueryOrderedChanges<T extends { _id: Stringable }> (
   oldResults: Array<T>,
   newResults: Array<T>,
   observer: ObserveChangesObserver<T["_id"], Omit<T, "_id">>,
@@ -118,7 +118,7 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
     clone = naiveClone,
     equals = naiveEquals
   }: DiffOptions = {}
-) {
+): Promise<void> {
   var projectionFn = projectionFn || clone;
 
   var newPresenceOfId = new Set<string>();
@@ -228,23 +228,30 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
   // an id of "null"
   unmoved.push(newResults.length);
 
-  oldResults.forEach(function (doc) {
-  if (!newPresenceOfId.has(stringId(doc._id)))
-    observer.observes("removed") && observer.removed && observer.removed(doc._id);
-  });
+  for (const doc of oldResults) {
+    if (!newPresenceOfId.has(stringId(doc._id))) {
+      if (observer.observes("removed") && observer.removed) {
+        await observer.removed(doc._id);
+      }
+    }
+  }
 
   // for each group of things in the new_results that is anchored by an unmoved
   // element, iterate through the things before it.
   let startOfGroup = 0;
-  unmoved.forEach(function (endOfGroup) {
+  for (const endOfGroup of unmoved) {
     const groupId = newResults[endOfGroup] ? newResults[endOfGroup]._id : undefined;
     let oldDoc, newDoc, fields, projectedNew, projectedOld;
     for (var i = startOfGroup; i < endOfGroup; i++) {
       newDoc = newResults[i];
       if (!oldIndexOfId.has(stringId(newDoc._id))) {
         fields = projectionFn(newDoc);
-        observer.observes("addedBefore") && observer.addedBefore(newDoc._id, fields, groupId);
-        observer.observes("added") && observer.added(newDoc._id, fields);
+        if (observer.observes("addedBefore")) {
+          await observer.addedBefore(newDoc._id, fields, groupId);
+        }
+        if (observer.observes("added")) {
+          await observer.added(newDoc._id, fields);
+        }
       }
       else {
         // moved
@@ -252,10 +259,12 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
         projectedNew = projectionFn(newDoc);
         projectedOld = projectionFn(oldDoc);
         const { hasChanges, changes: fields } = makeChangedFields(projectedOld, projectedNew, { equals });
-        if (hasChanges) {
-          observer.observes("changed") && observer.changed(newDoc._id, fields);
+        if (hasChanges && observer.observes("changed")) {
+          await observer.changed(newDoc._id, fields);
         }
-        observer.observes("movedBefore") && observer.movedBefore(newDoc._id, groupId);
+        if (observer.observes("movedBefore")) {
+          await observer.movedBefore(newDoc._id, groupId);
+        }
       }
     }
     if (newResults[endOfGroup]) {
@@ -264,12 +273,12 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
       projectedNew = projectionFn(newDoc);
       projectedOld = projectionFn(oldDoc);
       const { hasChanges, changes: fields } = makeChangedFields(projectedOld, projectedNew, { equals });
-      if (hasChanges) {
-        observer.observes("changed") && observer.changed(newDoc._id, fields);
+      if (hasChanges && observer.observes("changed")) {
+        await observer.changed(newDoc._id, fields);
       }
     }
     startOfGroup = endOfGroup + 1;
-  });
+  }
 };
 
 

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -258,7 +258,7 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
         observer.observes("movedBefore") && observer.movedBefore(newDoc._id, groupId);
       }
     }
-    if (groupId) {
+    if (newResults[endOfGroup]) {
       newDoc = newResults[endOfGroup];
       oldDoc = oldResults[oldIndex(stringId(newDoc._id))];
       projectedNew = projectionFn(newDoc);

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -66,7 +66,7 @@ type DiffOptions = {
   projectionFn?: <T>(doc: T) => any
 }
 
-export function diffQueryUnorderedChanges<ID extends Stringable, T>(
+export async function diffQueryUnorderedChanges<ID extends Stringable, T>(
   oldResults: StringableIdMap<ID, T>,
   newResults: StringableIdMap<ID, T>,
   observer: ObserveChangesObserver<ID, T>,
@@ -75,13 +75,13 @@ export function diffQueryUnorderedChanges<ID extends Stringable, T>(
     clone = naiveClone,
     equals = naiveEquals
   }: DiffOptions = {}
-) {
+): Promise<void> {
   if (observer.observes("added") || observer.observes("changed")) {
-    newResults.forEach((value, id) => {
+    for (const [id, value] of newResults) {
       const oldDoc = oldResults.get(id);
       if (!oldDoc) {
         if (observer.observes("added") && observer.added) {
-          observer.added(id, value);
+          await observer.added(id, value);
         }
       }
       else {
@@ -91,20 +91,20 @@ export function diffQueryUnorderedChanges<ID extends Stringable, T>(
           const projectedOld = projectionFn(oldDoc);
           var { hasChanges, changes: changedFields } = makeChangedFields(projectedOld, projectedNew, { equals });
           if (hasChanges) {
-            observer.changed(id, changedFields);
+            await observer.changed(id, changedFields);
           }
         }
       }
-    });
+    }
   }
   if (observer.observes("removed") && observer.removed) {
-    oldResults.forEach((value, id) => {
+    for (const [id] of oldResults) {
       if (!newResults.get(id)) {
         if (observer.removed) {
-          observer.removed(id);
+          await observer.removed(id);
         }
       }
-    });
+    }
   }
 }
 

--- a/src/multiplexer.ts
+++ b/src/multiplexer.ts
@@ -98,17 +98,17 @@ export class ObserveMultiplexer<
     return this._ordered ? ["addedBefore", "changed", "movedBefore", "removed"] : ["added", "changed", "removed"]
   }
 
-  #sendAdds = (handle: ObserveChangesObserver<ID, T>) => {
-    this.#cache.forEach((doc, _id) => {
+  #sendAdds = async (handle: ObserveChangesObserver<ID, T>) => {
+    await this.#cache.forEachAsync(async (doc, _id) => {
       if (!this.#handles.has(handle)) {
         throw Error("handle got removed before sending initial adds!");
       }
 
       if (this._ordered) {
-        handle.addedBefore(_id, doc, undefined);
+        await handle.addedBefore(_id, doc, undefined);
       }
       else {
-        handle.added(_id, doc);
+        await handle.added(_id, doc);
       }
     });
   }

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -123,7 +123,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
           return;
         }
         const addedAtIndex = indices
-          ? before
+          ? (before !== null && before !== undefined)
             ? cache.indexOf(before)
             : cache.size()
           : -1;
@@ -134,7 +134,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
 
         const doc = transform(cloneIfMutating({ _id: id, ...fields }));
 
-        const beforeDoc = before && transform(cloneIfMutating(cache.get(before)));
+        const beforeDoc = (before !== null && before !== undefined) && transform(cloneIfMutating(cache.get(before)));
 
         if (observeCallbacks.addedAt) {
           return observeCallbacks.addedAt(
@@ -180,12 +180,12 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
 
         const from = indices ? cache.indexOf(id) : -1;
         let to = indices
-          ? before
+          ? (before !== null && before !== undefined)
             ? cache.indexOf(before)
             : cache.size()
           : -1;
         cache.movedBefore(id, before);
-        const beforeDoc = before && transform(cloneIfMutating(cache.get(before)));
+        const beforeDoc = (before !== null && before !== undefined) && transform(cloneIfMutating(cache.get(before)));
 
         // When not moving backwards, adjust for the fact that removing the
         // document slides everything back one slot.

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -122,6 +122,11 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         if (suppressed) {
           return;
         }
+        const addedAtIndex = indices
+          ? before
+            ? cache.indexOf(before)
+            : cache.size()
+          : -1;
         cache.addedBefore(id, { _id: id, ...fields }, before);
         if (!(observeCallbacks.addedAt || observeCallbacks.added)) {
           return;
@@ -134,11 +139,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         if (observeCallbacks.addedAt) {
           return observeCallbacks.addedAt(
             doc,
-            indices
-              ? before
-                ? cache.indexOf(before)
-                : cache.size()
-              : -1,
+            addedAtIndex,
             beforeDoc
           );
         }

--- a/src/pollingDriver.ts
+++ b/src/pollingDriver.ts
@@ -105,7 +105,7 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
       if (this.#stopped) {
         return;
       }
-      diffQueryOrderedChanges<T>(
+      await diffQueryOrderedChanges<T>(
         Array.from(docs).map(([_id, doc]) => ({ _id, ...doc }) as T),
         Array.from(newDocs.entries()).map(([_id, doc]) => ({ _id, ...doc }) as T),
         this.#multiplexer,

--- a/src/pollingDriver.ts
+++ b/src/pollingDriver.ts
@@ -120,7 +120,7 @@ export class PollingDriver<T extends { _id: Stringable }> implements ObserveDriv
       if (this.#stopped) {
         return;
       }
-      diffQueryUnorderedChanges<T["_id"], T>(
+      await diffQueryUnorderedChanges<T["_id"], T>(
         docs,
         newDocs as StringableIdMap<T["_id"], T>,
         this.#multiplexer,

--- a/src/redis/manager.ts
+++ b/src/redis/manager.ts
@@ -18,6 +18,50 @@ type SubscriptionEntry = {
   handle: (message: RedisMessage) => void
 };
 
+// Decides whether an UPDATE message's changed FIELDS overlap a channel's
+// projection enough to warrant a findOne against the DB. Both sides are
+// normalized to top-level segments via key.split(".")[0] so { a: 1 } and
+// { "a.b": 1 } behave identically. For exclusion projections the logic is
+// inverted: we fetch iff at least one changed field is NOT in the excluded
+// set.
+//
+// Special cases:
+//   {} — all fields, always fetch.
+//   {_id: 1} — only _id, never fetch on a non-_id UPDATE.
+//   {_id: 0} — exclude only _id, always fetch on any non-_id UPDATE.
+function shouldFetchForFields(
+  projection: Document,
+  fields: string[] | undefined
+): boolean {
+  if (!fields) {
+    return true;
+  }
+  const allKeys = Object.keys(projection);
+  if (allKeys.length === 0) {
+    return true;
+  }
+  const nonIdKeys = allKeys.filter(k => k !== "_id");
+  let isExclusion: boolean;
+  let projTopLevel: Set<string>;
+  if (nonIdKeys.length === 0) {
+    // Only _id is mentioned. Inclusion form ({_id: 1}) means *only* _id
+    // is wanted; exclusion form ({_id: 0}) means everything except _id.
+    const idValue = projection._id;
+    isExclusion = idValue === 0 || idValue === false;
+    projTopLevel = isExclusion ? new Set(["_id"]) : new Set();
+  }
+  else {
+    const sampleValue = projection[nonIdKeys[0]];
+    isExclusion = sampleValue === 0 || sampleValue === false;
+    projTopLevel = new Set(nonIdKeys.map(k => k.split(".")[0]));
+  }
+  const fieldsTopLevel = fields.map(f => f.split(".")[0]);
+  if (isExclusion) {
+    return fieldsTopLevel.some(f => !projTopLevel.has(f));
+  }
+  return fieldsTopLevel.some(f => projTopLevel.has(f));
+}
+
 export class SubscriptionManager {
   #subscribers = new Map<string, SubscriptionEntry>();
   #pubSubManager: PubSubManager;
@@ -71,6 +115,11 @@ export class SubscriptionManager {
         this.#subscribers.delete(channel);
         this.#pubSubManager.unsubscribe(channel, entry.handle);
       }
+      else {
+        entry.projection = unionOfProjections(
+          [...entry.subscribers].map(s => s.completeProjection)
+        );
+      }
     });
   }
 
@@ -100,7 +149,13 @@ export class SubscriptionManager {
     };
     const collection: Collection<T> = entry.collection as Collection<T>;
 
-    // TODO: we should check if the fields intersect with the completeProjection
+    if (message[RedisPipe.EVENT] === Events.UPDATE) {
+      const fields = message[RedisPipe.FIELDS] as string[] | undefined;
+      if (!shouldFetchForFields(entry.projection, fields)) {
+        return;
+      }
+    }
+
     const doc = message[RedisPipe.EVENT] === Events.REMOVE
       ? message[RedisPipe.DOC]
       : await collection.findOne<T>(selector, { projection: entry.projection });

--- a/src/redis/manager.ts
+++ b/src/redis/manager.ts
@@ -19,11 +19,16 @@ type SubscriptionEntry = {
 };
 
 // Decides whether an UPDATE message's changed FIELDS overlap a channel's
-// projection enough to warrant a findOne against the DB. Both sides are
-// normalized to top-level segments via key.split(".")[0] so { a: 1 } and
-// { "a.b": 1 } behave identically. For exclusion projections the logic is
-// inverted: we fetch iff at least one changed field is NOT in the excluded
-// set.
+// projection enough to warrant a findOne against the DB.
+//
+// Inclusion projections normalize to top-level segments via
+// key.split(".")[0] — { a: 1 } and { "a.b": 1 } both want something under
+// `a`, so an update touching `a` is relevant in either case.
+//
+// Exclusion projections are NOT symmetric. { a: 0 } excludes the whole
+// top-level field, but { "a.b": 0 } only excludes one path under `a` —
+// the subscriber still wants a.c, a.x, etc. So a top-level field is
+// "fully excluded" only when an exact (no-dot) exclusion key matches it.
 //
 // Special cases:
 //   {} — all fields, always fetch.
@@ -41,24 +46,26 @@ function shouldFetchForFields(
     return true;
   }
   const nonIdKeys = allKeys.filter(k => k !== "_id");
-  let isExclusion: boolean;
-  let projTopLevel: Set<string>;
+  const fieldsTopLevel = fields.map(f => f.split(".")[0]);
   if (nonIdKeys.length === 0) {
     // Only _id is mentioned. Inclusion form ({_id: 1}) means *only* _id
     // is wanted; exclusion form ({_id: 0}) means everything except _id.
     const idValue = projection._id;
-    isExclusion = idValue === 0 || idValue === false;
-    projTopLevel = isExclusion ? new Set(["_id"]) : new Set();
+    const isExclusion = idValue === 0 || idValue === false;
+    if (isExclusion) {
+      return fieldsTopLevel.some(f => f !== "_id");
+    }
+    return fieldsTopLevel.some(f => f === "_id");
   }
-  else {
-    const sampleValue = projection[nonIdKeys[0]];
-    isExclusion = sampleValue === 0 || sampleValue === false;
-    projTopLevel = new Set(nonIdKeys.map(k => k.split(".")[0]));
-  }
-  const fieldsTopLevel = fields.map(f => f.split(".")[0]);
+  const sampleValue = projection[nonIdKeys[0]];
+  const isExclusion = sampleValue === 0 || sampleValue === false;
   if (isExclusion) {
-    return fieldsTopLevel.some(f => !projTopLevel.has(f));
+    // Only exact-top-level (dotless) keys fully exclude a top-level field.
+    // Dotted exclusions leave the rest of the top-level reachable.
+    const fullyExcluded = new Set(nonIdKeys.filter(k => !k.includes(".")));
+    return fieldsTopLevel.some(f => !fullyExcluded.has(f));
   }
+  const projTopLevel = new Set(nonIdKeys.map(k => k.split(".")[0]));
   return fieldsTopLevel.some(f => projTopLevel.has(f));
 }
 

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -58,10 +58,62 @@ export async function handleRemove(
   }
 }
 
+// Returns the union of top-level field names affected by `mutator`, or
+// `undefined` if the affected set is not statically knowable (replacement
+// updates and pipelines containing $replaceRoot/$replaceWith). Subscribers
+// treat absent FIELDS as "always fetch".
+export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefined {
+  if (mutator == null || typeof mutator !== "object") return undefined;
+
+  if (Array.isArray(mutator)) {
+    const fields = new Set<string>();
+    for (const stage of mutator) {
+      if (!stage || typeof stage !== "object" || Array.isArray(stage)) continue;
+      for (const [op, operand] of Object.entries(stage)) {
+        if (op === "$replaceRoot" || op === "$replaceWith") return undefined;
+        if (op === "$unset") {
+          if (typeof operand === "string") {
+            fields.add(operand.split(".")[0]);
+          }
+          else if (Array.isArray(operand)) {
+            for (const path of operand) {
+              if (typeof path === "string") fields.add(path.split(".")[0]);
+            }
+          }
+          continue;
+        }
+        if (op === "$set" || op === "$addFields" || op === "$project") {
+          if (operand && typeof operand === "object" && !Array.isArray(operand)) {
+            for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
+          }
+          continue;
+        }
+        // Unknown stage — be safe. If we ever hit this with a collection that still uses the old redis-oplog code, we'll have a problem
+        // this is OK - it's currently not used and we have no immediate plans to use it
+        return undefined;
+      }
+    }
+    return [...fields];
+  }
+
+  const entries = Object.entries(mutator);
+  if (entries.length === 0) return [];
+  // Replacement form: any non-$ top-level key means the whole doc is being
+  // replaced with that object, and removed fields aren't enumerable.
+  if (entries.some(([k]) => !k.startsWith("$"))) return undefined;
+
+  const fields = new Set<string>();
+  for (const [, operand] of entries) {
+    if (!operand || typeof operand !== "object" || Array.isArray(operand)) continue;
+    for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
+  }
+  return [...fields];
+}
+
 export async function handleUpdate(
   defaultChannel: string,
   _ids: Stringable[],
-  fields: string[],
+  fields: string[] | undefined,
   options: RedisOptions,
   publishOptions: PublishOptions
 ) {
@@ -72,10 +124,12 @@ export async function handleUpdate(
         const event: RedisUpdate<{ _id: Stringable }> = {
           [RedisPipe.EVENT]: Events.UPDATE,
           [RedisPipe.DOC]: { _id },
-          // @ts-expect-error we're going to trust that fields is the top level keys
-          [RedisPipe.FIELDS]: fields,
           [RedisPipe.UID]: publishOptions.uid
         };
+        if (fields !== undefined) {
+          // @ts-expect-error we're going to trust that fields is the top level keys
+          event[RedisPipe.FIELDS] = fields;
+        }
         try {
           await publishOptions.emit(channel, event, options);
         }
@@ -211,7 +265,7 @@ export function applyRedis<
     if (_id === null || _id === undefined) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
     await handleUpdate(defaultChannel, [_id as unknown as Stringable], fields, options as RedisOptions || {}, publishOptions);
   }, { tags: ["redis"], includeId: true });
 
@@ -219,7 +273,7 @@ export function applyRedis<
     args: [, mutator, options],
     _ids
   }) => {
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
     // TODO: what about partial deletion?
     await handleUpdate(defaultChannel, _ids as unknown as Stringable[], fields, options as RedisOptions || {}, publishOptions);
   }, { tags: ["redis"], includeIds: true });
@@ -246,7 +300,7 @@ export function applyRedis<
     if (!result) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
 
     const _id = idFromMaybeResult(result);
     if (_id === null || _id === undefined) {

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -60,7 +60,7 @@ export async function handleRemove(
 
 // Returns the union of top-level field names affected by `mutator`, or
 // `undefined` if the affected set is not statically knowable (replacement
-// updates and pipelines containing $replaceRoot/$replaceWith). Subscribers
+// updates and pipelines containing $project/$replaceRoot/$replaceWith). Subscribers
 // treat absent FIELDS as "always fetch".
 export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefined {
   if (mutator == null || typeof mutator !== "object") return undefined;
@@ -70,7 +70,7 @@ export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefine
     for (const stage of mutator) {
       if (!stage || typeof stage !== "object" || Array.isArray(stage)) continue;
       for (const [op, operand] of Object.entries(stage)) {
-        if (op === "$replaceRoot" || op === "$replaceWith") return undefined;
+        if (op === "$project" || op === "$replaceRoot" || op === "$replaceWith") return undefined;
         if (op === "$unset") {
           if (typeof operand === "string") {
             fields.add(operand.split(".")[0]);
@@ -82,7 +82,7 @@ export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefine
           }
           continue;
         }
-        if (op === "$set" || op === "$addFields" || op === "$project") {
+        if (op === "$set" || op === "$addFields") {
           if (operand && typeof operand === "object" && !Array.isArray(operand)) {
             for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
           }

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -162,7 +162,7 @@ export function applyRedis<
     resultOrig,
     error
   }) => {
-    let insertedIds = resultOrig?.insertedId ? [resultOrig.insertedId] : [];
+    let insertedIds = resultOrig?.insertedId !== null && resultOrig?.insertedId !== undefined ? [resultOrig.insertedId] : [];
     if ((error as BulkWriteError)?.insertedIds) {
       insertedIds = Object.values(error.insertedIds);
     }
@@ -191,7 +191,7 @@ export function applyRedis<
     args: [, options],
     _id
   }) => {
-    if (_id) { // it's entirely possible for deleteOne to not find a document to delete
+    if (_id !== null && _id !== undefined) { // it's entirely possible for deleteOne to not find a document to delete
       await handleRemove(defaultChannel, [_id as unknown as Stringable], options as RedisOptions, publishOptions);
     }
   }, { tags: ["redis"], includeId: true });
@@ -208,7 +208,7 @@ export function applyRedis<
     args: [, mutator, options],
     _id,
   }) => {
-    if (!_id) { // it's entirely possible for updateOne to not find a document to delete
+    if (_id === null || _id === undefined) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
     const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
@@ -232,7 +232,7 @@ export function applyRedis<
       return;
     }
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
 
@@ -249,7 +249,7 @@ export function applyRedis<
     const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
 
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     await handleUpdate(defaultChannel, [_id], fields, options as RedisOptions || {}, publishOptions);
@@ -264,7 +264,7 @@ export function applyRedis<
     }
 
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     // debatable - we're going to consider a replacement to be a remove + insert, otherwise it's hard to know which fields changed
@@ -281,7 +281,7 @@ export function applyRedis<
     }
 
     const _id = idFromMaybeResult(result as WithId<TSchema> | UpdateResult<TSchema>);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     // debatable - we're going to consider a replacement to be a remove + insert, otherwise it's hard to know which fields changed

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -354,7 +354,7 @@ export class RedisObserverDriver<
     if (this.#stopped) {
       return;
     }
-    diffQueryOrderedChanges(
+    await diffQueryOrderedChanges(
       [...this.#sortDocs.keys()].map(id => ({ _id: id })),
       [...newDocs.keys()].map(id => ({ _id: id })),
       {

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -442,7 +442,7 @@ export class RedisObserverDriver<
 
         if (options.limit && this.#sortDocs.size > options.limit && this.#sortDocs.tail) {
           const tail = this.#sortDocs.tail;
-          this.#sortDocs.remove(this.#sortDocs.tail.value);
+          this.#sortDocs.remove(tail.key);
           this.#multiplexer.removed(tail.value._id);
         }
       }
@@ -476,7 +476,7 @@ export class RedisObserverDriver<
       const allDocs = [sortableDoc, ...this.#sortDocs.values()].sort(this.#comparator);
       const index = allDocs.indexOf(sortableDoc);
       const before = allDocs[index + 1];
-      this.#sortDocs.add(this.#sortProjectionFn(doc), before);
+      this.#sortDocs.add(doc._id, this.#sortProjectionFn(doc), before?._id);
       this.#multiplexer.addedBefore(doc._id, this.#projectionFnWithMapWithoutId(doc), before?._id);
       if (options.limit && this.#sortDocs.size > options.limit) {
         if (this.#sortDocs.tail) {
@@ -552,7 +552,7 @@ export class RedisObserverDriver<
             const afterSortIndex = allDocs.findIndex(({ _id }) => _id === doc._id);
             const afterSortBefore = allDocs[afterSortIndex + 1];
             if (beforeSortIndex !== afterSortIndex) {
-              this.#multiplexer.movedBefore(doc._id, afterSortBefore);
+              this.#multiplexer.movedBefore(doc._id, afterSortBefore?._id);
             }
           }
         }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -76,8 +76,6 @@ export class RedisObserverDriver<
   #sortProjectionFn: (projection: Document) => SortT;
   #transform: (doc: any) => ET;
 
-  // down the road, we might merge sortDocs and docs - currently docs is totally unused and we rely on the multiplexer to track the current document
-  #docs: OrderedDict<T["_id"], SortT & T> | undefined;
   // #sortDocs contains the document ID + the fields necessary to evaluate the sort.
   #sortDocs: OrderedDict<T["_id"], SortT> | undefined;
   #strictRelevance: boolean;
@@ -221,9 +219,6 @@ export class RedisObserverDriver<
   }
 
   async #has(id: Stringable): Promise<boolean> {
-    if (this.#docs) {
-      return this.#docs.has(id);
-    }
     if (this.#multiplexer) {
       return this.#multiplexer.has(id);
     }
@@ -231,14 +226,6 @@ export class RedisObserverDriver<
   }
 
   async #get(id: Stringable): Promise<ET | undefined> {
-    if (this.#docs) {
-      const doc = this.#docs.get(id);
-      if (!doc) {
-        return;
-      }
-      const { _id, ...docMinusId } = this.#projectionFn(doc);
-      return docMinusId as unknown as ET;
-    }
     if (this.#multiplexer) {
       const multiDoc = await this.#multiplexer.get(id);
       if (!multiDoc) {
@@ -261,9 +248,6 @@ export class RedisObserverDriver<
     return this.#transform(rest);
   }
   async #size(): Promise<number> {
-    if (this.#docs) {
-      return this.#docs.size;
-    }
     if (!this.#multiplexer) {
       throw new Error("Neither docs nor multiplexer");
     }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -481,7 +481,7 @@ export class RedisObserverDriver<
       if (options.limit && this.#sortDocs.size > options.limit) {
         if (this.#sortDocs.tail) {
           const tail = this.#sortDocs.tail;
-          this.#sortDocs.remove(tail.value);
+          this.#sortDocs.remove(tail.key);
           this.#multiplexer.removed(tail.value._id);
         }
       }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -324,7 +324,12 @@ export class RedisObserverDriver<
     }
     else if (message[RedisPipe.EVENT] === Events.REMOVE) {
       const doc = message[RedisPipe.DOC];
-      this.#multiplexer.removed(doc._id);
+      if (await this.#has(doc._id)) {
+        if (this.#stopped) {
+          return;
+        }
+        this.#multiplexer.removed(doc._id);
+      }
       return;
     }
     throw new Error("not implemented");

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -120,8 +120,12 @@ export class RedisObserverDriver<
     this.#channels = this.#getChannels(channelsFromOptions);
     this.#strictRelevance = options.strictRelevance || true;
     if (this.#cursor.cursorDescription.options.sort) {
-      this.#comparator = new options.Sorter(this.#cursor.cursorDescription.options.sort).getComparator();
-      this.#sortProjection = Object.fromEntries(Object.entries(this.#cursor.cursorDescription.options.sort).map(([key]) => [key, 1])) as NestedProjectionOfTSchema<SortT>
+      const rawSort = this.#cursor.cursorDescription.options.sort;
+      const sortObject = Array.isArray(rawSort)
+        ? Object.fromEntries(rawSort)
+        : rawSort;
+      this.#comparator = new options.Sorter(sortObject).getComparator();
+      this.#sortProjection = Object.fromEntries(Object.keys(sortObject).map((key) => [key, 1])) as NestedProjectionOfTSchema<SortT>
       // @ts-expect-error
       this.#sortProjectionFn = options.compileProjection(this.#sortProjection) as (doc: T & SortT & FilterT) => SortT;
       this.#combinedProjection = unionOfProjections<T & SortT>([
@@ -369,7 +373,7 @@ export class RedisObserverDriver<
             {
               projection: unionOfProjections([
                 this.#cursor.cursorDescription.options.projection as NestedProjectionOfTSchema<T>,
-                Object.fromEntries(Object.entries(this.#cursor.cursorDescription.options.sort || {}).map(([key]) => [key, 1])) as NestedProjectionOfTSchema<T>,
+                (this.#sortProjection || {}) as NestedProjectionOfTSchema<T>,
                 this.#matcher._path
               ])
             }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -370,13 +370,7 @@ export class RedisObserverDriver<
           const actualDoc = id === newCommer._id ? newCommer as T & SortT : await this.#collection.findOne(
             // @ts-expect-error
             { _id: id },
-            {
-              projection: unionOfProjections([
-                this.#cursor.cursorDescription.options.projection as NestedProjectionOfTSchema<T>,
-                (this.#sortProjection || {}) as NestedProjectionOfTSchema<T>,
-                this.#matcher._path
-              ])
-            }
+            { projection: this.completeProjection }
           ) as T & SortT;
           if (!actualDoc) {
             return;

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -384,7 +384,7 @@ export class RedisObserverDriver<
           if (!item) {
             return;
           }
-          this.#sortDocs?.remove(item);
+          this.#sortDocs?.remove(item._id);
           this.#multiplexer?.removed(item._id);
         },
 

--- a/src/redis/types.ts
+++ b/src/redis/types.ts
@@ -20,7 +20,7 @@ export type RedisInsert<T extends { _id: Stringable }> = {
 export type RedisUpdate<T extends { _id: Stringable }> = {
   [RedisPipe.EVENT]: typeof Events.UPDATE,
   [RedisPipe.DOC]: T,
-  [RedisPipe.FIELDS]: (keyof T & string)[],
+  [RedisPipe.FIELDS]?: (keyof T & string)[],
   [RedisPipe.UID]: Stringable
 }
 

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -5,10 +5,14 @@ import { Stringable } from "../types.js";
 
 enum OperationType {
   OID = "oid",
-  FILTER = "filter"
+  FILTER = "filter",
+  EMPTY = "empty"
 };
 function getType(id: (ObjectId | FilterOperators<Stringable>)): OperationType {
   const firstKey = Object.keys(id)[0];
+  if (firstKey === undefined) {
+    return OperationType.EMPTY;
+  }
   if (firstKey.startsWith("$")) {
     return OperationType.FILTER;
   }
@@ -22,7 +26,7 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     const andIds = selector.$and.map(extractIdsFromSelector);
     andIds.forEach(idSet => idSet.forEach(id => ids.add(id)));
   }
-  if (selector._id) {
+  if (selector._id !== null && selector._id !== undefined) {
     if (typeof selector._id === "string" || typeof selector._id === "number") {
       ids.add(selector._id);
     }
@@ -32,7 +36,10 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     else {
       const idField: ObjectId | FilterOperators<Stringable> = selector._id as ObjectId | FilterOperators<Stringable>;
       const type = getType(idField);
-      if (type === OperationType.FILTER) {
+      if (type === OperationType.EMPTY) {
+        // empty object {} — nothing to extract
+      }
+      else if (type === OperationType.FILTER) {
         const idFilter = idField as FilterOperators<Stringable>;
         // Skip null/undefined - stringId would crash trying to read `_bsontype` on them.
         idFilter.$in?.forEach(id => {
@@ -72,7 +79,7 @@ export function getStrategy<T extends { _id: Stringable }> (
       return Strategy.DEFAULT;
   }
 
-  if (selector && selector._id) {
+  if (selector && selector._id !== null && selector._id !== undefined) {
       return Strategy.DEDICATED_CHANNELS;
   }
 

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -33,6 +33,9 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     else if (selector._id instanceof RegExp || (selector._id as BSONRegExp)._bsontype === "BSONRegExp") {
       // do nothing
     }
+    else if (selector._id instanceof Date) {
+      ids.add(selector._id);
+    }
     else {
       const idField: ObjectId | FilterOperators<Stringable> = selector._id as ObjectId | FilterOperators<Stringable>;
       const type = getType(idField);

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -27,7 +27,7 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     andIds.forEach(idSet => idSet.forEach(id => ids.add(id)));
   }
   if (selector._id !== null && selector._id !== undefined) {
-    if (typeof selector._id === "string" || typeof selector._id === "number") {
+    if (typeof selector._id === "string" || typeof selector._id === "number" || typeof selector._id === "boolean") {
       ids.add(selector._id);
     }
     else if (selector._id instanceof RegExp || (selector._id as BSONRegExp)._bsontype === "BSONRegExp") {

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -35,7 +35,7 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
         if (next.done) {
           return next;
         }
-        return { next: false, value: fromStringId(next.value as string) as ID}
+        return { done: false, value: fromStringId(next.value as string) as ID};
       },
       [Symbol.iterator]() {
         return this;

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -1,8 +1,19 @@
 import { Stringable, fromStringId, stringId } from "./types.js";
 
 export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, T> {
-  constructor(entries?: [ID, T][]) {
-    super(entries?.map(([key, value]) => [stringId(key), value]));
+  constructor(entries?: Iterable<readonly [ID, T]> | null) {
+    // the else is more correct, but 99.9% of the time we'll be passing in an array, and I don't want to risk changing behaviour to satisfy typescript
+    if (entries && Array.isArray(entries)) {
+      super((entries as [ID, T][])?.map(([key, value]) => [stringId(key), value]));
+    }
+    else {
+      super();
+      if (entries) {
+        for (const [key, value] of entries) {
+          super.set(stringId(key), value);
+        }
+      }
+    }
   }
 
   delete(key: ID | string): boolean {
@@ -22,7 +33,7 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
     return this;
   }
 
-  [Symbol.species]() {
+  static get [Symbol.species]() {
     return StringableIdMap;
   }
 

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -33,10 +33,6 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
     return this;
   }
 
-  static get [Symbol.species]() {
-    return StringableIdMap;
-  }
-
   keys(): MapIterator<ID | string> {
     const iterator = super.keys();
     // @ts-ignore - vscode doesn't mind this, but tsc does

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,7 @@ export type CachingChangeObserverOptions = {
 
 export type CachingChangeObserver<ID extends Stringable, T extends StringObjectWithoutID> = ObserveChangesObserver<ID, T> & {
   forEach(iterator: (doc: T, id: ID) => void): void;
+  forEachAsync(iterator: (doc: T, id: ID) => void | Promise<void>): Promise<void>;
   indexOf(id: ID): number;
   size(): number;
   get(id: ID): T | undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,16 +17,17 @@ export type Stringable = string
   // | { toHexString() : string } // this is a proxy for ObjectId - see above.
   | Date
   | number
+  | boolean
   | ObjectId
   | {[k in string]: Stringable }// Record<string, Stringable>
   | Stringable[];
 
 type EJSONItem = { $type: "oid", $value: string } | { $type: "date", $value: number }
-type Item = EJSONItem | string | number | { [k in string]: Item } | Item[];
+type Item = EJSONItem | string | number | boolean | { [k in string]: Item } | Item[];
 
 
 function jsonable(stringable: Stringable): Item {
-  if (typeof stringable === "string" || typeof stringable === "number") {
+  if (typeof stringable === "string" || typeof stringable === "number" || typeof stringable === "boolean") {
     return stringable;
   }
   if (stringable instanceof Date) {
@@ -49,7 +50,10 @@ export function stringId(stringable: Stringable): string {
   return JSON.stringify(jsonable(stringable));
 }
 
-function jsonToObject(json: { $type: "oid" | "date", $value: any } | { [k in string]: string | number | { $type: "oid" | "date", $value: any } }): Stringable {
+function jsonToObject(json: { $type: "oid" | "date", $value: any } | { [k in string]: string | number | { $type: "oid" | "date", $value: any } } | null): Stringable {
+  if (json === null) {
+    return null as unknown as Stringable;
+  }
   if (json.$type) {
     if (json.$type === "date") {
       return new Date(json.$value);
@@ -95,6 +99,9 @@ export function naiveEquals<T>(doc1: T, doc2: T): boolean {
 
 export type Clone = <T>(doc: T) => T;
 export function naiveClone<T>(doc: T): T {
+  if (doc === undefined) {
+    return doc;
+  }
   return JSON.parse(JSON.stringify(doc));
 }
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,0 +1,36 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { diffQueryOrderedChanges } from "../lib/diff.js";
+
+describe("diffQueryOrderedChanges", () => {
+  it("should fire changed for an unmoved anchor with falsy _id (regression: TODO 6)", () => {
+    // The LCS algorithm marks every common doc as a "group anchor" and (when
+    // its content changed) fires `changed` for it. The buggy `if (groupId)`
+    // check was meant to skip the virtual end-of-list anchor (where
+    // groupId === undefined) but also skipped legitimate falsy ids like
+    // 0 / "" / false — so a doc with _id: 0 whose content changed never got
+    // a `changed` event for its anchor branch.
+    const oldResults = [
+      { _id: 0, value: "old" },
+      { _id: "1", value: "b" }
+    ];
+    const newResults = [
+      { _id: 0, value: "new" },
+      { _id: "1", value: "b" }
+    ];
+    const changed = mock.fn();
+    diffQueryOrderedChanges(oldResults, newResults, {
+      observes: (h) => h === "changed",
+      addedBefore: () => {},
+      movedBefore: () => {},
+      added: () => {},
+      removed: () => {},
+      changed
+    });
+
+    assert.ok(
+      changed.mock.calls.some(c => c.arguments[0] === 0),
+      "changed should fire for the _id: 0 anchor when its content has changed"
+    );
+  });
+});

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,8 +1,40 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
+import { setTimeout } from "node:timers/promises";
 import { diffQueryOrderedChanges } from "../lib/diff.js";
 
 describe("diffQueryOrderedChanges", () => {
+  it("should await async observer hooks (regression: TODO B)", async () => {
+    // The function used to iterate observer hooks via Array.forEach and
+    // discard any returned promises. Callers like RedisObserverDriver#requery
+    // pass an observer whose addedBefore is async (it awaits collection.findOne
+    // before mutating sortDocs and notifying the multiplexer). With the diff
+    // sync, the caller's `await diff(...)` returned before the async hook
+    // finished — so subsequent message processing raced against in-flight
+    // findOne / sortDocs.add work.
+    let callbackCompleted = false;
+    const oldResults = [{ _id: "1" }];
+    const newResults = [{ _id: "1" }, { _id: "2" }];
+
+    await diffQueryOrderedChanges(oldResults, newResults, {
+      observes: () => true,
+      addedBefore: async () => {
+        await setTimeout(10);
+        callbackCompleted = true;
+      },
+      added: () => {},
+      changed: () => {},
+      movedBefore: () => {},
+      removed: () => {}
+    });
+
+    assert.strictEqual(
+      callbackCompleted,
+      true,
+      "diffQueryOrderedChanges must await async observer hooks before resolving"
+    );
+  });
+
   it("should fire changed for an unmoved anchor with falsy _id (regression: TODO 6)", () => {
     // The LCS algorithm marks every common doc as a "group anchor" and (when
     // its content changed) fires `changed` for it. The buggy `if (groupId)`

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,7 +1,42 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
 import { setTimeout } from "node:timers/promises";
-import { diffQueryOrderedChanges } from "../lib/diff.js";
+import { diffQueryOrderedChanges, diffQueryUnorderedChanges } from "../lib/diff.js";
+import { StringableIdMap } from "../lib/stringableIdMap.js";
+
+describe("diffQueryUnorderedChanges", () => {
+  it("should await async observer hooks (regression: TODO C)", async () => {
+    // Same shape as TODO B, on the unordered diff. forEach over the
+    // StringableIdMap discarded the promises returned by observer hooks
+    // so any async caller (current callers happen to be sync via the
+    // multiplexer queue, but external callers and a future async
+    // multiplexer would silently race).
+    let callbackCompleted = false;
+    const oldResults = new StringableIdMap();
+    oldResults.set("1", { value: "a" });
+    const newResults = new StringableIdMap();
+    newResults.set("1", { value: "a" });
+    newResults.set("2", { value: "b" });
+
+    await diffQueryUnorderedChanges(oldResults, newResults, {
+      observes: (h) => h === "added",
+      added: async () => {
+        await setTimeout(10);
+        callbackCompleted = true;
+      },
+      addedBefore: () => {},
+      changed: () => {},
+      movedBefore: () => {},
+      removed: () => {}
+    });
+
+    assert.strictEqual(
+      callbackCompleted,
+      true,
+      "diffQueryUnorderedChanges must await async observer hooks before resolving"
+    );
+  });
+});
 
 describe("diffQueryOrderedChanges", () => {
   it("should await async observer hooks (regression: TODO B)", async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,6 @@ import "./cachingChangeObserver.js";
 import "./orderedDict.js";
 import "./fromMeteor.js";
 import "./client.js";
+import "./types.js";
+import "./diff.js";
+import "./publish.js";

--- a/test/multiplexer.js
+++ b/test/multiplexer.js
@@ -38,6 +38,48 @@ class NoopDriver extends PollingDriver {
 
 
 describe("multiplexer", () => {
+  it("addHandleAndSendInitialAdds should await async handle callbacks (regression: TODO A)", async () => {
+    // The cache is empty for the first handle, so the bug only manifests
+    // when a SECOND handle attaches to a multiplexer with existing docs.
+    // #sendAdds previously called handle.added without awaiting, so
+    // addHandleAndSendInitialAdds would resolve before the user's async
+    // callback completed.
+    const multiplexer = new ObserveMultiplexer({ ordered: false });
+
+    // First handle to populate the cache.
+    const noopHandle = {
+      observes: () => true,
+      added: () => {},
+      addedBefore: () => {},
+      changed: () => {},
+      movedBefore: () => {},
+      removed: () => {}
+    };
+    multiplexer.addHandleAndSendInitialAdds(noopHandle);
+    multiplexer.added("a", { value: 1 });
+    multiplexer.ready();
+    await multiplexer.flush();
+
+    let resolved = false;
+    const slowHandle = {
+      observes: () => true,
+      added: async () => {
+        await setTimeout(10);
+        resolved = true;
+      },
+      addedBefore: async () => {},
+      changed: async () => {},
+      movedBefore: async () => {},
+      removed: async () => {}
+    };
+    await multiplexer.addHandleAndSendInitialAdds(slowHandle);
+
+    assert.strictEqual(
+      resolved,
+      true,
+      "addHandleAndSendInitialAdds should not resolve until handle.added completes"
+    );
+  });
   it("should add the initial items to the first handle", async () => {
     const collection = new FakeCollection([{ _id: "test" }, { _id: "test2" }]);
     const cursor = collection.find({});

--- a/test/observe.js
+++ b/test/observe.js
@@ -395,6 +395,54 @@ describe("unordered observe", () => {
 });
 
 describe("ordered observe", () => {
+  it("addedAt receives the actual index of the inserted document", async () => {
+    const collection = new FakeCollection([{ _id: "test" }]);
+    const cursor = collection.find({});
+    const addedMock = mock.fn();
+    const handle = await observe(
+      cursor,
+      collection,
+      { addedAt: addedMock },
+      { ordered: true, pollingInterval: 5 }
+    );
+
+    assert.strictEqual(addedMock.mock.callCount(), 1, "should have seen the initial add");
+    assert.strictEqual(
+      addedMock.mock.calls[0].arguments[1],
+      0,
+      "addedAt should report index 0 for the first document"
+    );
+    handle.stop();
+  });
+  it("addedAt receives the actual index when a document is inserted before another", async () => {
+    const collection = new FakeCollection([{ _id: "a", field: 1 }]);
+    const cursor = collection.find({}, { sort: { field: 1 } });
+    const addedMock = mock.fn();
+    const handle = await observe(
+      cursor,
+      collection,
+      { addedAt: addedMock },
+      { ordered: true, pollingInterval: 5 }
+    );
+
+    assert.strictEqual(addedMock.mock.callCount(), 1, "should have seen the initial add");
+
+    cursor._data.unshift({ _id: "b", field: 0 });
+    await setTimeout(10);
+
+    assert.strictEqual(addedMock.mock.callCount(), 2, "should have seen the new add");
+    assert.strictEqual(
+      addedMock.mock.calls[1].arguments[0]._id,
+      "b",
+      "second addedAt call should be for the new doc"
+    );
+    assert.strictEqual(
+      addedMock.mock.calls[1].arguments[1],
+      0,
+      "addedAt should report index 0 for a doc inserted before all existing docs"
+    );
+    handle.stop();
+  });
   it("additional addedBefores are received", async () => {
     const data = [{ _id: "test" }, { _id: "test2" }];
     const collection = new FakeCollection(data);

--- a/test/publish.js
+++ b/test/publish.js
@@ -1,6 +1,7 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
 import { applyRedis } from "../lib/redis/publish.js";
+import { RedisPipe } from "../lib/redis/constants.js";
 
 function makeMockCollection() {
   const callbacks = new Map();
@@ -44,6 +45,69 @@ describe("applyRedis", () => {
     });
 
     assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is updated");
+  });
+
+  it("should compute FIELDS from a pipeline-form mutator (regression: TODO 5)", async () => {
+    // Pipeline-form update: an array of stages. Today's parser does
+    // `Object.values(mutator).flatMap($m => Object.keys($m))` which on an
+    // array yields the *operator names* (e.g., '$set'), not the affected
+    // fields. The subscriber-side fetch filter then sees ['$set'] which
+    // never matches a projection — the change is silently dropped.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $set: { a: 1 } }, { $unset: ["b"] }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should publish at least one message");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.deepStrictEqual(
+      [...(message[RedisPipe.FIELDS] || [])].sort(),
+      ["a", "b"],
+      "FIELDS should be the union of LHS keys across pipeline stages"
+    );
+  });
+
+  it("should omit FIELDS for a pipeline with $replaceWith (regression: TODO 5)", async () => {
+    // $replaceWith / $replaceRoot replaces the doc with an arbitrary
+    // expression. The affected field set is not statically knowable, so
+    // emit no FIELDS — the consumer (shouldFetchForFields) treats absent
+    // fields as "always fetch", which is the safe behavior.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $replaceWith: { a: "$x", b: 2 } }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should still publish");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.strictEqual(
+      message[RedisPipe.FIELDS],
+      undefined,
+      "FIELDS should be absent so subscribers re-fetch"
+    );
+  });
+
+  it("should not crash when a mutator operand is null (regression: TODO 5)", async () => {
+    // Defensive: an operator whose value is null (e.g., {$set: null}) used
+    // to throw `Object.keys(null)` and propagate up the hook chain.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await assert.doesNotReject(
+      cb({ args: [{}, { $set: null }, {}], _id: "x" }),
+      "publisher should not throw on a null operator value"
+    );
   });
 
   it("should publish for insertOne when insertedId is 0 (regression: TODO 6)", async () => {

--- a/test/publish.js
+++ b/test/publish.js
@@ -1,0 +1,65 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { applyRedis } from "../lib/redis/publish.js";
+
+function makeMockCollection() {
+  const callbacks = new Map();
+  const collection = {
+    collectionName: "tests",
+    callbacks,
+    on(event, cb) {
+      callbacks.set(event, cb);
+      return collection;
+    }
+  };
+  return collection;
+}
+
+describe("applyRedis", () => {
+  it("should publish for deleteOne when _id is 0 (regression: TODO 6)", async () => {
+    // The buggy `if (_id)` truthy check skipped publishing for any deleteOne
+    // whose _id happens to be falsy (0, "", false). The fix uses an
+    // explicit null/undefined comparison so falsy-but-real ids still emit.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.deleteOne.success");
+    await cb({ args: [{}, {}], _id: 0 });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is deleted");
+  });
+
+  it("should publish for updateOne when _id is 0 (regression: TODO 6)", async () => {
+    // Same falsy-id issue on the updateOne path: `if (!_id) return;` would
+    // skip publishing. The fix tightens the guard to null/undefined.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, { $set: { value: 1 } }, {}],
+      _id: 0
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is updated");
+  });
+
+  it("should publish for insertOne when insertedId is 0 (regression: TODO 6)", async () => {
+    // The insert path computed `resultOrig?.insertedId ? [...] : []` — an
+    // _id of 0 was treated as "no insert" and never published.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.insertOne");
+    await cb({
+      args: [{ _id: 0 }, {}],
+      resultOrig: { acknowledged: true, insertedId: 0 },
+      error: undefined
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is inserted");
+  });
+});

--- a/test/publish.js
+++ b/test/publish.js
@@ -96,6 +96,28 @@ describe("applyRedis", () => {
     );
   });
 
+  it("should omit FIELDS for a pipeline with $project", async () => {
+    // Inclusion-form $project names the retained fields, not every removed
+    // field. The affected field set is therefore not statically knowable.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $project: { kept: 1 } }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should still publish");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.strictEqual(
+      message[RedisPipe.FIELDS],
+      undefined,
+      "FIELDS should be absent so subscribers re-fetch"
+    );
+  });
+
   it("should not crash when a mutator operand is null (regression: TODO 5)", async () => {
     // Defensive: an operator whose value is null (e.g., {$set: null}) used
     // to throw `Object.keys(null)` and propagate up the hook chain.

--- a/test/redis.js
+++ b/test/redis.js
@@ -531,6 +531,59 @@ describe("Redis Observer", () => {
         "should only subscribe to channels for non-null, non-undefined ids"
       );
     });
+
+    it("should not throw when filter is _id: {} (regression: TODO 4)", () => {
+      // getStrategy picks DEDICATED_CHANNELS because selector._id is truthy.
+      // extractIdsFromSelector then calls getType({}); Object.keys({})[0] is
+      // undefined and undefined.startsWith("$") throws TypeError.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      assert.doesNotThrow(() => {
+        new RedisObserverDriver(
+          collection.find({ _id: {} }, {}),
+          collection,
+          {
+            ordered: false,
+            manager: subscriptionManager,
+            Matcher: Minimongo.Matcher
+          }
+        );
+      });
+    });
+
+    // SKIPPED: regression test for TODO 1 (`strictRelevance` cannot be set to false).
+    // `#strictRelevance` is a private field that nothing reads — the assignment
+    // bug is real (`||` should be `??`) but has no externally observable effect
+    // until either (a) the documented behavior described on `RedisObserverDriverOptions.strictRelevance`
+    // is actually wired through to the projection/filter logic, or (b) the field
+    // is exposed via a public getter for testing. Add a real test once one of
+    // those happens.
+    it.skip("should respect strictRelevance: false (regression: TODO 1)", () => {});
+
+    it("should subscribe to a dedicated channel for literal _id: 0 (regression: TODO 6)", () => {
+      // Two truthy checks erase 0 as a legitimate _id:
+      //   - getStrategy: `if (selector && selector._id)` falls through to DEFAULT for _id: 0.
+      //   - extractIdsFromSelector: `if (selector._id)` skips the value entirely.
+      // Net effect: a doc with _id: 0 never gets a dedicated channel and no
+      // live updates are received for it.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: 0 }, {}),
+        collection,
+        {
+          ordered: false,
+          manager: subscriptionManager,
+          Matcher: Minimongo.Matcher
+        }
+      );
+
+      assert.deepStrictEqual(subscriber.channels, [`${collectionName}::0`]);
+    });
   });
   describe("limit sort processor", () => {
     // insert test cases

--- a/test/redis.js
+++ b/test/redis.js
@@ -851,6 +851,43 @@ describe("Redis Observer", () => {
     // those happens.
     it.skip("should respect strictRelevance: false (regression: TODO 1)", () => {});
 
+    it("should subscribe to a dedicated channel for a Date _id (regression: TODO 11)", () => {
+      // getType(new Date()) returns EMPTY because Object.keys(date) is [],
+      // so the Date is silently dropped from extractIdsFromSelector and
+      // the subscriber registers no per-id channel.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const date = new Date(0);
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: date }, {}),
+        collection,
+        { ordered: false, manager: subscriptionManager, Matcher: Minimongo.Matcher }
+      );
+      assert.deepStrictEqual(
+        subscriber.channels,
+        [`${collectionName}::${stringId(date)}`],
+        "should produce a per-id channel keyed on the stringified Date"
+      );
+    });
+
+    it("should subscribe to a dedicated channel for a Date _id under $eq (regression: TODO 11)", () => {
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const date = new Date(0);
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: { $eq: date } }, {}),
+        collection,
+        { ordered: false, manager: subscriptionManager, Matcher: Minimongo.Matcher }
+      );
+      assert.deepStrictEqual(
+        subscriber.channels,
+        [`${collectionName}::${stringId(date)}`],
+        "should produce a per-id channel for { $eq: Date }"
+      );
+    });
+
     it("should subscribe to a dedicated channel for literal _id: 0 (regression: TODO 6)", () => {
       // Two truthy checks erase 0 as a legitimate _id:
       //   - getStrategy: `if (selector && selector._id)` falls through to DEFAULT for _id: 0.

--- a/test/redis.js
+++ b/test/redis.js
@@ -1722,6 +1722,54 @@ describe("Redis Observer", () => {
       assert.strictEqual(spy.mock.callCount(), 1, "{_id: 0} excludes only _id — 'c' is wanted, must fetch");
     });
 
+    it("projection { 'a.b.c': 0 } (deep exclusion) + FIELDS=['a'] should fetch", async () => {
+      // Deep-path exclusion only blocks `a.b.c` — the subscriber still
+      // wants the rest of `a` (e.g., a.b.d, a.x). An update touching the
+      // top-level `a` may have changed any of those, so we must fetch.
+      // Top-level normalization (k.split('.')[0]) is correct for inclusion
+      // but loses information for exclusion: only exact-top-level keys
+      // (no dot) actually exclude the whole top-level field.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ "a.b.c": 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(
+        spy.mock.callCount(),
+        1,
+        "deep exclusion: top-level 'a' may still be needed — must fetch"
+      );
+    });
+
+    it("projection { a: 0, 'b.c': 0 } + FIELDS=['a'] should NOT fetch", async () => {
+      // Companion to the FIELDS=['b'] case: 'a' has an exact-top-level
+      // exclusion, so the subscriber doesn't want anything under 'a'.
+      // An update touching only 'a' is irrelevant — skip the fetch.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 0, "b.c": 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(
+        spy.mock.callCount(),
+        0,
+        "exact-top-level exclusion of 'a' covers the whole field — skip"
+      );
+    });
+
+    it("projection { a: 0, 'b.c': 0 } + FIELDS=['b'] should fetch", async () => {
+      // Mixed exact + dotted exclusion. 'a' is fully excluded; 'b' is only
+      // partially (only b.c blocked) so an update touching 'b' may have
+      // changed b.d, b.x, etc. — must fetch.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 0, "b.c": 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["b"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(
+        spy.mock.callCount(),
+        1,
+        "partial top-level exclusion: 'b' isn't fully excluded — must fetch"
+      );
+    });
+
     it("projection {} (empty = all fields) + FIELDS=['c'] should fetch", async () => {
       // Empty projection means "all fields" in Mongo semantics, so any
       // update could be relevant — must always fetch.

--- a/test/redis.js
+++ b/test/redis.js
@@ -875,6 +875,25 @@ describe("Redis Observer", () => {
     });
   });
   describe("limit sort processor", () => {
+    it("should not throw when requery runs with no filter (regression: TODO 4)", async () => {
+      // No filter → no matcher → #requery accessing this.#matcher._path
+      // would throw TypeError on the first cross-window insert with skip.
+      // The throw is swallowed by the queue's default error handler
+      // (console.warn), so the failure surfaces as a missing addedBefore.
+      const { collection, multiplexer, subscriber } = await setup(
+        undefined,
+        { sort: { number: 1 }, skip: 1 },
+        [{ _id: "1", number: 1 }]
+      );
+      const addedBeforeMock = mock.method(multiplexer, "addedBefore");
+      await collection.insertOne({ _id: "2", number: 0 });
+      await subscriber._queue.flush();
+      assert.strictEqual(
+        addedBeforeMock.mock.callCount(),
+        1,
+        "should have called addedBefore for the doc that became visible after skip"
+      );
+    });
     it("should accept array-form sort and produce a sort projection by field name (regression: TODO 3)", async () => {
       const { subscriber } = await setup(
         {},

--- a/test/redis.js
+++ b/test/redis.js
@@ -308,6 +308,42 @@ describe("Redis Observer", () => {
       await subscriber._queue.flush();
       assert.strictEqual(addedMock.mock.callCount(), 1, "Should not have called added again");
     });
+    it("should not fire removed for unknown ids (regression: TODO 11)", async () => {
+      // The default-strategy REMOVE branch in #processDefaultMessage fires
+      // multiplexer.removed unconditionally, unlike the UPDATE branch and
+      // the dedicated-channels path, which both guard with `await this.#has`.
+      // Downstream observers should never see a `removed` for an id that
+      // was never `added`.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [{ _id: "known" }], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const cursor = collection.find({}, {});
+      const multiplexer = new ObserveMultiplexer({ ordered: false });
+      const subscriber = new RedisObserverDriver(
+        cursor,
+        collection,
+        {
+          ordered: false,
+          manager: subscriptionManager,
+          Matcher: Minimongo.Matcher
+        }
+      );
+
+      multiplexer.addHandleAndSendInitialAdds({ observes() { return false; } });
+      await subscriber.init(multiplexer);
+      await subscriber._queue.flush();
+
+      const removedMock = mock.method(multiplexer, "removed");
+
+      await pubSubManager.emit(collectionName, {
+        [RedisPipe.EVENT]: Events.REMOVE,
+        [RedisPipe.DOC]: { _id: "unknown" },
+        [RedisPipe.UID]: "someone-else"
+      });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(removedMock.mock.callCount(), 0, "should not forward removed for an id the subscriber never added");
+    });
   });
   describe("dedicated channels processor", () => {
     it("Initial added works", async () => {

--- a/test/redis.js
+++ b/test/redis.js
@@ -1057,6 +1057,94 @@ describe("Redis Observer", () => {
       assert.strictEqual(addedBeforeMock.mock.calls[0].arguments[1].name, "one", "should include non-sort fields in the document");
     });
 
+    it("should key #sortDocs by _id when inserting in the middle (regression: line 479)", async () => {
+      const { collection, multiplexer, subscriber } = await setup(
+        { value: { $lt: 10 } },
+        { sort: { number: 1 } },
+        [{ _id: "1", number: 1, value: 5 }, { _id: "3", number: 3, value: 5 }]
+      );
+
+      // Middle insert. The buggy add() call passed the sort projection as
+      // the key (instead of doc._id) and the before-doc as the value, so
+      // #sortDocs ended up with the entry under a stringified-sortFields
+      // key. multiplexer.addedBefore still fires (so callers see the new
+      // doc), but #sortDocs.has(doc._id) is now false.
+      await collection.insertOne({ _id: "2", number: 2, value: 5 });
+      await subscriber._queue.flush();
+
+      const removedMock = mock.method(multiplexer, "removed");
+
+      // Make _id "2" ineligible. The UPDATE handler checks #sortDocs.has —
+      // if true it fires removed, if false it returns silently. With the
+      // bug "2" isn't keyed by its _id so the removed event never fires.
+      await collection.updateOne({ _id: "2" }, { $set: { value: 100 } });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(removedMock.mock.callCount(), 1, "should have fired removed when the ineligible doc was in the set");
+      assert.strictEqual(removedMock.mock.calls[0].arguments[0], "2");
+    });
+
+    it("should evict the actual tail on overflow when inserting before the head (regression: line 445)", async () => {
+      const { collection, multiplexer, subscriber } = await setup(
+        {},
+        { sort: { number: 1 }, limit: 2 },
+        [{ _id: "1", number: 1 }, { _id: "2", number: 2 }]
+      );
+
+      const removedMock = mock.method(multiplexer, "removed");
+
+      // First overflow: insert "0" before head, evicts "2".
+      await collection.insertOne({ _id: "0", number: 0 });
+      await subscriber._queue.flush();
+
+      // Second overflow: insert "-1" before head. With a clean #sortDocs the
+      // new tail is "1" so we'd evict "1". The buggy code passed tail.value
+      // (a SortT, not the key) to OrderedDict.remove() so the eviction was a
+      // silent no-op and #sortDocs.tail kept pointing at the stale "2" — so
+      // the second overflow tries to evict "2" again.
+      await collection.insertOne({ _id: "-1", number: -1 });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(removedMock.mock.callCount(), 2);
+      assert.strictEqual(removedMock.mock.calls[0].arguments[0], "2");
+      assert.strictEqual(
+        removedMock.mock.calls[1].arguments[0],
+        "1",
+        "second overflow should evict '1' (the new tail), not the stale '2'"
+      );
+    });
+
+    it("should evict the actual tail on overflow when inserting in the middle (regression: line 484)", async () => {
+      const { collection, multiplexer, subscriber } = await setup(
+        {},
+        { sort: { number: 1 }, limit: 2 },
+        [{ _id: "1", number: 1 }, { _id: "3", number: 3 }]
+      );
+
+      const addedBeforeMock = mock.method(multiplexer, "addedBefore");
+
+      // Middle insert with overflow: "2" lands between "1" and "3" and "3"
+      // should be evicted from #sortDocs. Buggy code passed tail.value to
+      // remove() so #sortDocs still contains "3" with #sortDocs.tail
+      // pointing at it.
+      await collection.insertOne({ _id: "2", number: 2 });
+      await subscriber._queue.flush();
+
+      // Insert "2.5". With a clean #sortDocs the tail is "2" (n=2) so the
+      // doc lands AFTER the tail — limit is full, no event. With the buggy
+      // state #sortDocs.tail is still "3" (n=3) so the driver routes the
+      // doc through the middle path and (incorrectly) emits another
+      // addedBefore.
+      await collection.insertOne({ _id: "2.5", number: 2.5 });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(
+        addedBeforeMock.mock.callCount(),
+        1,
+        "second insert should produce no new addedBefore — it sorts after the new tail and the limit is full"
+      );
+    });
+
     it("should clean up sortDocs in requery's removed callback", async () => {
       const {
         collection,

--- a/test/redis.js
+++ b/test/redis.js
@@ -875,6 +875,18 @@ describe("Redis Observer", () => {
     });
   });
   describe("limit sort processor", () => {
+    it("should accept array-form sort and produce a sort projection by field name (regression: TODO 3)", async () => {
+      const { subscriber } = await setup(
+        {},
+        { sort: [["number", 1]], projection: { thing: 1 } },
+        [{ _id: "1", number: 1, thing: "a" }]
+      );
+      assert.deepStrictEqual(
+        subscriber.completeProjection,
+        { thing: 1, number: 1 },
+        "completeProjection should be keyed by field name, not array index"
+      );
+    });
     // insert test cases
     it("should call addedBefore when inserting a document AFTER the set, without a limit", async () => {
       const {

--- a/test/redis.js
+++ b/test/redis.js
@@ -1,5 +1,6 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
+import { setTimeout } from "node:timers/promises";
 import { Minimongo } from "@blastjs/minimongo";
 import { LocalCollection } from "@blastjs/minimongo/dist/local_collection.js";
 import { FakeCollection } from "mongo-collection-helpers/testHelpers";
@@ -1232,6 +1233,46 @@ describe("Redis Observer", () => {
         1,
         "second insert should produce no new addedBefore — it sorts after the new tail and the limit is full"
       );
+    });
+
+    it("requery should await async addedBefore callbacks under real I/O latency (regression: TODO B)", async () => {
+      const { collection, multiplexer, subscriber } = await setup(
+        { value: { $lt: 10 } },
+        { sort: { number: 1 }, limit: 2 },
+        [
+          { _id: "1", number: 1, value: 5 },
+          { _id: "2", number: 2, value: 5 },
+          { _id: "3", number: 3, value: 5 }
+        ]
+      );
+
+      // Wrap findOne with a real timeout so the async addedBefore handler
+      // in #requery cannot complete in the same scheduler turn as the
+      // subscriber queue. Without diffQueryOrderedChanges awaiting the
+      // returned promise, subscriber._queue.flush() resolves before the
+      // multiplexer is notified about the new doc.
+      const originalFindOne = collection.findOne.bind(collection);
+      collection.findOne = async (...args) => {
+        await setTimeout(10);
+        return originalFindOne(...args);
+      };
+
+      const addedBeforeMock = mock.method(multiplexer, "addedBefore");
+      const removedMock = mock.method(multiplexer, "removed");
+
+      // Make _id "1" ineligible. With limit=2 and #sortDocs.size=2, the
+      // UPDATE handler routes through requery, which produces a synchronous
+      // removed("1") and an async addedBefore("3") (awaiting findOne).
+      await collection.updateOne({ _id: "1" }, { $set: { value: 100 } });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(removedMock.mock.callCount(), 1, "removed should fire for _id '1'");
+      assert.strictEqual(
+        addedBeforeMock.mock.callCount(),
+        1,
+        "addedBefore should fire for _id '3' before flush returns"
+      );
+      assert.strictEqual(addedBeforeMock.mock.calls[0].arguments[0], "3");
     });
 
     it("should clean up sortDocs in requery's removed callback", async () => {

--- a/test/redis.js
+++ b/test/redis.js
@@ -1057,5 +1057,45 @@ describe("Redis Observer", () => {
       assert.strictEqual(addedBeforeMock.mock.calls[0].arguments[1].name, "one", "should include non-sort fields in the document");
     });
 
+    it("should clean up sortDocs in requery's removed callback", async () => {
+      const {
+        collection,
+        multiplexer,
+        subscriber
+      } = await setup(
+        { value: { $lt: 10 } },
+        { sort: { number: 1 }, limit: 2 },
+        [
+          { _id: "1", number: 1, value: 5 },
+          { _id: "2", number: 2, value: 5 },
+          { _id: "3", number: 3, value: 5 }
+        ]
+      );
+
+      // Make _id "1" ineligible. With limit=2 and #sortDocs.size=2, this hits
+      // the requery branch in #processLimitSortMessage. The requery's `removed`
+      // callback fires for "1"; the buggy code passed the stored value to
+      // OrderedDict.remove() instead of the id, so the entry under "1" was
+      // never removed and "1" leaked as the head of #sortDocs.
+      await collection.updateOne({ _id: "1" }, { $set: { value: 100 } });
+      await subscriber._queue.flush();
+
+      // Insert a doc that sorts before the new head. With a clean #sortDocs
+      // the head is "2", so addedBefore is called with before="2". With the
+      // leak the head is the stale "1", so addedBefore is called with
+      // before="1" — which the multiplexer no longer knows about.
+      const addedBeforeMock = mock.method(multiplexer, "addedBefore");
+      await collection.insertOne({ _id: "0", number: 0, value: 5 });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(addedBeforeMock.mock.callCount(), 1, "should have called addedBefore once for the new doc");
+      assert.strictEqual(addedBeforeMock.mock.calls[0].arguments[0], "0");
+      assert.strictEqual(
+        addedBeforeMock.mock.calls[0].arguments[2],
+        "2",
+        "addedBefore should reference the new head '2', not the stale '1'"
+      );
+    });
+
   });
 });

--- a/test/redis.js
+++ b/test/redis.js
@@ -309,6 +309,258 @@ describe("Redis Observer", () => {
       await subscriber._queue.flush();
       assert.strictEqual(addedMock.mock.callCount(), 1, "Should not have called added again");
     });
+    it("subscriber A (projection {name:1}) should not receive subscriber B's 'secret' in changed fields (regression: TODO G - cross-pollution)", async () => {
+      // Two subscribers on the same channel with disjoint projections.
+      //   A: projection { name: 1 }
+      //   B: projection { secret: 1 }
+      // Manager unions their completeProjections, so when an UPDATE comes in
+      // it fetches both `name` and `secret` from the DB and forwards a doc
+      // containing both fields to BOTH subscribers. If A's pipeline doesn't
+      // re-project, A's downstream observer would see `secret` in the
+      // changed-fields payload — which is a real correctness leak (and an
+      // information-disclosure leak if the field is sensitive).
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(
+        collectionName,
+        [{ _id: "1", name: "a", secret: "shh" }],
+        pubSubManager
+      );
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const changedA = mock.fn();
+      const handleA = {
+        observes: () => true,
+        added: () => {},
+        addedBefore: () => {},
+        changed: changedA,
+        movedBefore: () => {},
+        removed: () => {}
+      };
+
+      const cursorA = collection.find({}, { projection: { name: 1 } });
+      const multiplexerA = new ObserveMultiplexer({ ordered: false });
+      multiplexerA.addHandleAndSendInitialAdds(handleA);
+      const subscriberA = new RedisObserverDriver(cursorA, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberA.init(multiplexerA);
+
+      const cursorB = collection.find({}, { projection: { secret: 1 } });
+      const multiplexerB = new ObserveMultiplexer({ ordered: false });
+      multiplexerB.addHandleAndSendInitialAdds({ observes: () => false });
+      const subscriberB = new RedisObserverDriver(cursorB, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberB.init(multiplexerB);
+
+      // Update both name and secret in a single mutator.
+      await collection.updateOne({ _id: "1" }, { $set: { name: "b", secret: "shh2" } });
+      await subscriberA._queue.flush();
+      await multiplexerA.flush();
+
+      assert.ok(changedA.mock.callCount() > 0, "A should receive a changed callback");
+      for (const call of changedA.mock.calls) {
+        const fields = call.arguments[1];
+        assert.ok(
+          !("secret" in fields),
+          `A's changed payload should not include 'secret', got ${JSON.stringify(fields)}`
+        );
+      }
+    });
+
+    it("subscriber A (projection {name:1}) should not fire 'changed' when only B's 'secret' is updated (regression: TODO G - cross-pollution)", async () => {
+      // Same setup as the previous test, but the update touches ONLY a
+      // field outside A's projection. Even though the manager fetches
+      // `secret` (because of the union projection), A's projectionFn
+      // strips it, makeChangedFields finds no changes against A's cache,
+      // and A's `changed` callback should never fire.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(
+        collectionName,
+        [{ _id: "1", name: "a", secret: "shh" }],
+        pubSubManager
+      );
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const changedA = mock.fn();
+      const handleA = {
+        observes: () => true,
+        added: () => {},
+        addedBefore: () => {},
+        changed: changedA,
+        movedBefore: () => {},
+        removed: () => {}
+      };
+
+      const cursorA = collection.find({}, { projection: { name: 1 } });
+      const multiplexerA = new ObserveMultiplexer({ ordered: false });
+      multiplexerA.addHandleAndSendInitialAdds(handleA);
+      const subscriberA = new RedisObserverDriver(cursorA, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberA.init(multiplexerA);
+
+      const cursorB = collection.find({}, { projection: { secret: 1 } });
+      const multiplexerB = new ObserveMultiplexer({ ordered: false });
+      multiplexerB.addHandleAndSendInitialAdds({ observes: () => false });
+      const subscriberB = new RedisObserverDriver(cursorB, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberB.init(multiplexerB);
+
+      await collection.updateOne({ _id: "1" }, { $set: { secret: "shh2" } });
+      await subscriberA._queue.flush();
+      await multiplexerA.flush();
+
+      assert.strictEqual(
+        changedA.mock.callCount(),
+        0,
+        "A should not fire 'changed' when only B's 'secret' field was updated"
+      );
+    });
+
+    it("manager should shrink projection union when a subscriber detaches (regression: TODO G)", async () => {
+      // Two subscribers share a channel (default strategy → collection-name
+      // channel) but with disjoint projections + filters.
+      //   A: filter on `priority`, projection on `name`
+      //   B: filter on `category`, projection on `secret`
+      // SubscriptionManager.attach unions their completeProjections so
+      // findOne fetches every monitored field. SubscriptionManager.detach
+      // removes B from the subscribers set but does not shrink
+      // entry.projection — so even after B is gone, the manager still
+      // fetches B's fields on every UPDATE for the channel.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(
+        collectionName,
+        [{ _id: "1", name: "a", category: "X", priority: 3, secret: "shh" }],
+        pubSubManager
+      );
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const cursorA = collection.find({ priority: { $lt: 5 } }, { projection: { name: 1 } });
+      const multiplexerA = new ObserveMultiplexer({ ordered: false });
+      const subscriberA = new RedisObserverDriver(cursorA, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      multiplexerA.addHandleAndSendInitialAdds({ observes() { return false; } });
+      await subscriberA.init(multiplexerA);
+
+      const cursorB = collection.find({ category: "X" }, { projection: { secret: 1 } });
+      const multiplexerB = new ObserveMultiplexer({ ordered: false });
+      const subscriberB = new RedisObserverDriver(cursorB, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      multiplexerB.addHandleAndSendInitialAdds({ observes() { return false; } });
+      await subscriberB.init(multiplexerB);
+
+      // B is no longer interested.
+      subscriberB.stop();
+
+      const findOneSpy = mock.method(collection, "findOne");
+
+      await collection.updateOne({ _id: "1" }, { $set: { name: "b" } });
+      await subscriberA._queue.flush();
+
+      // Locate the manager's findOne call (it carries entry.projection,
+      // which is more than just `{ _id: 1 }` used by other call sites).
+      const managerCall = findOneSpy.mock.calls.find(
+        c => c.arguments[1]?.projection && Object.keys(c.arguments[1].projection).length > 1
+      );
+      assert.ok(managerCall, "expected the manager to call findOne with the channel's union projection");
+
+      const projection = managerCall.arguments[1].projection;
+      assert.ok(
+        !("secret" in projection),
+        `after subscriberB.stop() the channel projection should not include B's projected 'secret' field; got ${JSON.stringify(projection)}`
+      );
+      assert.ok(
+        !("category" in projection),
+        `after subscriberB.stop() the channel projection should not include B's filter 'category' field; got ${JSON.stringify(projection)}`
+      );
+    });
+
+    it("manager should not fetch on updates touching only a removed subscriber's fields (regression: TODO G)", async () => {
+      // Setup: A (projection {name:1}) and B (projection {secret:1}) on the
+      // same channel. After B.stop(), an UPDATE touching only `secret`
+      // should not result in a findOne against the DB — the channel no
+      // longer cares about that field. This requires two things to be true:
+      //   1. entry.projection shrinks on detach (no `secret` after B leaves).
+      //   2. The manager checks message[RedisPipe.FIELDS] against
+      //      entry.projection and skips findOne when there's no overlap.
+      // (#1 alone isn't enough: entry.projection would be {name} but the
+      //  manager still unconditionally fetches.)
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(
+        collectionName,
+        [{ _id: "1", name: "a", secret: "shh" }],
+        pubSubManager
+      );
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const cursorA = collection.find({}, { projection: { name: 1 } });
+      const multiplexerA = new ObserveMultiplexer({ ordered: false });
+      multiplexerA.addHandleAndSendInitialAdds({ observes: () => false });
+      const subscriberA = new RedisObserverDriver(cursorA, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberA.init(multiplexerA);
+
+      const cursorB = collection.find({}, { projection: { secret: 1 } });
+      const multiplexerB = new ObserveMultiplexer({ ordered: false });
+      multiplexerB.addHandleAndSendInitialAdds({ observes: () => false });
+      const subscriberB = new RedisObserverDriver(cursorB, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriberB.init(multiplexerB);
+
+      subscriberB.stop();
+
+      const findOneSpy = mock.method(collection, "findOne");
+
+      // Touches only `secret`, which is no longer in any remaining
+      // subscriber's projection.
+      await collection.updateOne({ _id: "1" }, { $set: { secret: "shh2" } });
+      await subscriberA._queue.flush();
+
+      // CollectionThatEmits.updateOne issues its own findOne with
+      // `{ projection: { _id: 1 } }`; filter that out and look for any
+      // channel-level fetch (one that asks for `name` or `secret`).
+      const channelFindOnes = findOneSpy.mock.calls.filter(c => {
+        const proj = c.arguments[1]?.projection;
+        return proj && ("name" in proj || "secret" in proj);
+      });
+
+      assert.strictEqual(
+        channelFindOnes.length,
+        0,
+        `manager should skip findOne when message FIELDS don't intersect the (post-detach) entry.projection; got ${JSON.stringify(channelFindOnes.map(c => c.arguments[1].projection))}`
+      );
+    });
+
     it("should not fire removed for unknown ids (regression: TODO 11)", async () => {
       // The default-strategy REMOVE branch in #processDefaultMessage fires
       // multiplexer.removed unconditionally, unlike the UPDATE branch and
@@ -1315,5 +1567,169 @@ describe("Redis Observer", () => {
       );
     });
 
+  });
+
+  describe("manager FIELDS / projection intersection (regression: TODO G fetch filtering)", () => {
+    // These tests gate on a future change to SubscriptionManager.process:
+    // when an UPDATE message's RedisPipe.FIELDS doesn't overlap the
+    // channel's entry.projection (top-level), the manager should skip
+    // the findOne entirely.
+    //
+    // Cases marked "should fetch" are contract guards that already pass.
+    // Cases marked "should NOT fetch" are regression gates that fail on
+    // current code and will pass once the FIELDS-intersection check lands.
+    //
+    // Top-level normalization (`key.split(".")[0]`) on both projection
+    // keys and FIELDS makes the supported projection forms behave
+    // identically:
+    //   { a: 1 }          → top-level "a"
+    //   { "a.b": 1 }      → top-level "a"
+    //
+    // Note: MongoDB also accepts the nested-object form { a: { b: 1 } }
+    // as equivalent to { "a.b": 1 }, but Minimongo's _compileProjection
+    // rejects it with `Projection values should be one of 1, 0, true, or
+    // false`. Since this codebase passes user projections through
+    // _compileProjection during subscriber construction, the nested form
+    // never reaches the manager — there's no need to test it for
+    // FIELDS-intersection. See the dedicated test below that documents
+    // this restriction.
+
+    async function setupSingle(projection) {
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(
+        collectionName,
+        [{ _id: "1", a: { b: 1, c: 2 }, c: 3, name: "x" }],
+        pubSubManager
+      );
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const cursor = collection.find({}, { projection });
+      const multiplexer = new ObserveMultiplexer({ ordered: false });
+      multiplexer.addHandleAndSendInitialAdds({ observes: () => false });
+      const subscriber = new RedisObserverDriver(cursor, collection, {
+        ordered: false,
+        manager: subscriptionManager,
+        Matcher: Minimongo.Matcher,
+        compileProjection: LocalCollection._compileProjection
+      });
+      await subscriber.init(multiplexer);
+      return { pubSubManager, collection, subscriber };
+    }
+
+    async function emitUpdate(pubSubManager, fields) {
+      await pubSubManager.emit(collectionName, {
+        [RedisPipe.EVENT]: Events.UPDATE,
+        [RedisPipe.DOC]: { _id: "1" },
+        [RedisPipe.FIELDS]: fields,
+        [RedisPipe.UID]: "someone-else"
+      });
+    }
+
+    // The spy is attached after init, so all calls it sees come from
+    // SubscriptionManager.process (the only path that calls findOne with
+    // a projection in this setup).
+
+    it("projection { a: 1 } + FIELDS=['a'] should fetch", async () => {
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "FIELDS overlap projection at top-level — must fetch");
+    });
+
+    it("projection { a: 1 } + FIELDS=['c'] should NOT fetch", async () => {
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 0, "no overlap — fetch must be skipped");
+    });
+
+    it("nested-object projection { a: { b: 1 } } is rejected by Minimongo (so the FIELDS-intersection check never sees this form)", async () => {
+      await assert.rejects(
+        () => setupSingle({ a: { b: 1 } }),
+        /Projection values should be one of 1, 0, true, or false/
+      );
+    });
+
+    it("projection { 'a.b': 1 } + FIELDS=['a'] should fetch", async () => {
+      const { pubSubManager, collection, subscriber } = await setupSingle({ "a.b": 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "dotted projection: top-level 'a' overlaps — must fetch");
+    });
+
+    it("projection { 'a.b': 1 } + FIELDS=['c'] should NOT fetch", async () => {
+      const { pubSubManager, collection, subscriber } = await setupSingle({ "a.b": 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 0, "dotted projection: 'c' doesn't overlap 'a' — skip");
+    });
+
+    it("projection { 'a.b': 1 } + FIELDS=['a.b'] should fetch (defensive normalize)", async () => {
+      // FIELDS as produced by publish.ts is always top-level (split on ".").
+      // But if some other producer sends a dotted FIELDS entry, the
+      // intersection check should defensively normalize that too.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ "a.b": 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a.b"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "defensive: 'a.b' top-level normalizes to 'a' — must fetch");
+    });
+
+    it("projection { a: 0 } (exclusion) + FIELDS=['a'] should NOT fetch", async () => {
+      // Exclusion projection: subscriber explicitly does NOT want field `a`.
+      // An update touching only `a` is irrelevant — must skip.
+      // The semantics invert relative to inclusion: fetch iff FIELDS
+      // contains any key NOT in the excluded set.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["a"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 0, "exclusion: 'a' was excluded — irrelevant change, skip");
+    });
+
+    it("projection { a: 0 } (exclusion) + FIELDS=['c'] should fetch", async () => {
+      // 'c' isn't in the excluded set, so the subscriber wants to see
+      // its updates. Must fetch.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ a: 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "exclusion: 'c' isn't excluded — relevant change, fetch");
+    });
+
+    it("projection { _id: 1 } (only _id) + FIELDS=['c'] should NOT fetch", async () => {
+      // {_id: 1} is an inclusion projection that includes ONLY `_id`.
+      // No update to any other field is relevant to this subscriber.
+      // (Unlike `{}` which means "all fields", `{_id: 1}` means "only _id".)
+      const { pubSubManager, collection, subscriber } = await setupSingle({ _id: 1 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 0, "{_id: 1} includes only _id — no other-field update is relevant");
+    });
+
+    it("projection { _id: 0 } (exclude only _id) + FIELDS=['c'] should fetch", async () => {
+      // {_id: 0} is an exclusion projection that excludes ONLY _id.
+      // The subscriber wants every other field — must fetch on any
+      // non-_id update.
+      const { pubSubManager, collection, subscriber } = await setupSingle({ _id: 0 });
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "{_id: 0} excludes only _id — 'c' is wanted, must fetch");
+    });
+
+    it("projection {} (empty = all fields) + FIELDS=['c'] should fetch", async () => {
+      // Empty projection means "all fields" in Mongo semantics, so any
+      // update could be relevant — must always fetch.
+      const { pubSubManager, collection, subscriber } = await setupSingle({});
+      const spy = mock.method(collection, "findOne");
+      await emitUpdate(pubSubManager, ["c"]);
+      await subscriber._queue.flush();
+      assert.strictEqual(spy.mock.callCount(), 1, "empty projection means all fields — must always fetch");
+    });
   });
 });

--- a/test/types.js
+++ b/test/types.js
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { stringId, fromStringId, naiveClone } from "../lib/types.js";
+
+describe("stringId", () => {
+  it("should produce distinct ids for true and false (regression: TODO 7)", () => {
+    // jsonable() falls through for booleans to Object.entries() which returns
+    // [], so JSON.stringify yields "{}" for any boolean — true and false
+    // collide on the same channel/cache key.
+    assert.notStrictEqual(stringId(true), stringId(false));
+  });
+});
+
+describe("fromStringId", () => {
+  it("should not throw on a JSON-encoded array containing null (regression: TODO 13)", () => {
+    // JSON.parse("[null]") → [null]. jsonToObject hits the array branch and
+    // recurses into jsonToObject(null); accessing null.$type throws TypeError.
+    assert.doesNotThrow(() => fromStringId("[null]"));
+  });
+});
+
+describe("naiveClone", () => {
+  it("should not throw on undefined input (regression: TODO 12)", () => {
+    // observe.ts (lines 132/196) calls cloneIfMutating(cache.get(before))
+    // where cache.get can return undefined under upstream race conditions.
+    // naiveClone(undefined) is JSON.parse(JSON.stringify(undefined)) =
+    // JSON.parse(undefined) which throws SyntaxError. The fix can live
+    // either at the call site (guard before cloning) or here (handle
+    // undefined); either way naiveClone(undefined) should not crash.
+    assert.doesNotThrow(() => naiveClone(undefined));
+  });
+});


### PR DESCRIPTION
A series of bugs that I'd expect to be caught by typescript, but thanks to generics aren't - these are real world bugs, mostly around how ordered observers are handled when the order changes:

Includes these merged down PRs:
https://github.com/znewsham/observe-mongo/pull/20
https://github.com/znewsham/observe-mongo/pull/21
https://github.com/znewsham/observe-mongo/pull/22
https://github.com/znewsham/observe-mongo/pull/23