### PR TITLE
Unreal bugs

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -258,7 +258,7 @@ export function diffQueryOrderedChanges<T extends { _id: Stringable }> (
         observer.observes("movedBefore") && observer.movedBefore(newDoc._id, groupId);
       }
     }
-    if (groupId) {
+    if (newResults[endOfGroup]) {
       newDoc = newResults[endOfGroup];
       oldDoc = oldResults[oldIndex(stringId(newDoc._id))];
       projectedNew = projectionFn(newDoc);

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -162,7 +162,7 @@ export function applyRedis<
     resultOrig,
     error
   }) => {
-    let insertedIds = resultOrig?.insertedId ? [resultOrig.insertedId] : [];
+    let insertedIds = resultOrig?.insertedId !== null && resultOrig?.insertedId !== undefined ? [resultOrig.insertedId] : [];
     if ((error as BulkWriteError)?.insertedIds) {
       insertedIds = Object.values(error.insertedIds);
     }
@@ -191,7 +191,7 @@ export function applyRedis<
     args: [, options],
     _id
   }) => {
-    if (_id) { // it's entirely possible for deleteOne to not find a document to delete
+    if (_id !== null && _id !== undefined) { // it's entirely possible for deleteOne to not find a document to delete
       await handleRemove(defaultChannel, [_id as unknown as Stringable], options as RedisOptions, publishOptions);
     }
   }, { tags: ["redis"], includeId: true });
@@ -208,7 +208,7 @@ export function applyRedis<
     args: [, mutator, options],
     _id,
   }) => {
-    if (!_id) { // it's entirely possible for updateOne to not find a document to delete
+    if (_id === null || _id === undefined) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
     const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
@@ -232,7 +232,7 @@ export function applyRedis<
       return;
     }
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
 
@@ -249,7 +249,7 @@ export function applyRedis<
     const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
 
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     await handleUpdate(defaultChannel, [_id], fields, options as RedisOptions || {}, publishOptions);
@@ -264,7 +264,7 @@ export function applyRedis<
     }
 
     const _id = idFromMaybeResult(result);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     // debatable - we're going to consider a replacement to be a remove + insert, otherwise it's hard to know which fields changed
@@ -281,7 +281,7 @@ export function applyRedis<
     }
 
     const _id = idFromMaybeResult(result as WithId<TSchema> | UpdateResult<TSchema>);
-    if (!_id) {
+    if (_id === null || _id === undefined) {
       return;
     }
     // debatable - we're going to consider a replacement to be a remove + insert, otherwise it's hard to know which fields changed

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -324,7 +324,12 @@ export class RedisObserverDriver<
     }
     else if (message[RedisPipe.EVENT] === Events.REMOVE) {
       const doc = message[RedisPipe.DOC];
-      this.#multiplexer.removed(doc._id);
+      if (await this.#has(doc._id)) {
+        if (this.#stopped) {
+          return;
+        }
+        this.#multiplexer.removed(doc._id);
+      }
       return;
     }
     throw new Error("not implemented");

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -5,10 +5,14 @@ import { Stringable } from "../types.js";
 
 enum OperationType {
   OID = "oid",
-  FILTER = "filter"
+  FILTER = "filter",
+  EMPTY = "empty"
 };
 function getType(id: (ObjectId | FilterOperators<Stringable>)): OperationType {
   const firstKey = Object.keys(id)[0];
+  if (firstKey === undefined) {
+    return OperationType.EMPTY;
+  }
   if (firstKey.startsWith("$")) {
     return OperationType.FILTER;
   }
@@ -22,7 +26,7 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     const andIds = selector.$and.map(extractIdsFromSelector);
     andIds.forEach(idSet => idSet.forEach(id => ids.add(id)));
   }
-  if (selector._id) {
+  if (selector._id !== null && selector._id !== undefined) {
     if (typeof selector._id === "string" || typeof selector._id === "number") {
       ids.add(selector._id);
     }
@@ -32,7 +36,10 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     else {
       const idField: ObjectId | FilterOperators<Stringable> = selector._id as ObjectId | FilterOperators<Stringable>;
       const type = getType(idField);
-      if (type === OperationType.FILTER) {
+      if (type === OperationType.EMPTY) {
+        // empty object {} — nothing to extract
+      }
+      else if (type === OperationType.FILTER) {
         const idFilter = idField as FilterOperators<Stringable>;
         // Skip null/undefined - stringId would crash trying to read `_bsontype` on them.
         idFilter.$in?.forEach(id => {
@@ -72,7 +79,7 @@ export function getStrategy<T extends { _id: Stringable }> (
       return Strategy.DEFAULT;
   }
 
-  if (selector && selector._id) {
+  if (selector && selector._id !== null && selector._id !== undefined) {
       return Strategy.DEDICATED_CHANNELS;
   }
 

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -27,7 +27,7 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     andIds.forEach(idSet => idSet.forEach(id => ids.add(id)));
   }
   if (selector._id !== null && selector._id !== undefined) {
-    if (typeof selector._id === "string" || typeof selector._id === "number") {
+    if (typeof selector._id === "string" || typeof selector._id === "number" || typeof selector._id === "boolean") {
       ids.add(selector._id);
     }
     else if (selector._id instanceof RegExp || (selector._id as BSONRegExp)._bsontype === "BSONRegExp") {

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -35,7 +35,7 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
         if (next.done) {
           return next;
         }
-        return { next: false, value: fromStringId(next.value as string) as ID}
+        return { done: false, value: fromStringId(next.value as string) as ID};
       },
       [Symbol.iterator]() {
         return this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,16 +17,17 @@ export type Stringable = string
   // | { toHexString() : string } // this is a proxy for ObjectId - see above.
   | Date
   | number
+  | boolean
   | ObjectId
   | {[k in string]: Stringable }// Record<string, Stringable>
   | Stringable[];
 
 type EJSONItem = { $type: "oid", $value: string } | { $type: "date", $value: number }
-type Item = EJSONItem | string | number | { [k in string]: Item } | Item[];
+type Item = EJSONItem | string | number | boolean | { [k in string]: Item } | Item[];
 
 
 function jsonable(stringable: Stringable): Item {
-  if (typeof stringable === "string" || typeof stringable === "number") {
+  if (typeof stringable === "string" || typeof stringable === "number" || typeof stringable === "boolean") {
     return stringable;
   }
   if (stringable instanceof Date) {
@@ -49,7 +50,10 @@ export function stringId(stringable: Stringable): string {
   return JSON.stringify(jsonable(stringable));
 }
 
-function jsonToObject(json: { $type: "oid" | "date", $value: any } | { [k in string]: string | number | { $type: "oid" | "date", $value: any } }): Stringable {
+function jsonToObject(json: { $type: "oid" | "date", $value: any } | { [k in string]: string | number | { $type: "oid" | "date", $value: any } } | null): Stringable {
+  if (json === null) {
+    return null as unknown as Stringable;
+  }
   if (json.$type) {
     if (json.$type === "date") {
       return new Date(json.$value);
@@ -95,6 +99,9 @@ export function naiveEquals<T>(doc1: T, doc2: T): boolean {
 
 export type Clone = <T>(doc: T) => T;
 export function naiveClone<T>(doc: T): T {
+  if (doc === undefined) {
+    return doc;
+  }
   return JSON.parse(JSON.stringify(doc));
 }
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,0 +1,36 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { diffQueryOrderedChanges } from "../lib/diff.js";
+
+describe("diffQueryOrderedChanges", () => {
+  it("should fire changed for an unmoved anchor with falsy _id (regression: TODO 6)", () => {
+    // The LCS algorithm marks every common doc as a "group anchor" and (when
+    // its content changed) fires `changed` for it. The buggy `if (groupId)`
+    // check was meant to skip the virtual end-of-list anchor (where
+    // groupId === undefined) but also skipped legitimate falsy ids like
+    // 0 / "" / false — so a doc with _id: 0 whose content changed never got
+    // a `changed` event for its anchor branch.
+    const oldResults = [
+      { _id: 0, value: "old" },
+      { _id: "1", value: "b" }
+    ];
+    const newResults = [
+      { _id: 0, value: "new" },
+      { _id: "1", value: "b" }
+    ];
+    const changed = mock.fn();
+    diffQueryOrderedChanges(oldResults, newResults, {
+      observes: (h) => h === "changed",
+      addedBefore: () => {},
+      movedBefore: () => {},
+      added: () => {},
+      removed: () => {},
+      changed
+    });
+
+    assert.ok(
+      changed.mock.calls.some(c => c.arguments[0] === 0),
+      "changed should fire for the _id: 0 anchor when its content has changed"
+    );
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,6 @@ import "./cachingChangeObserver.js";
 import "./orderedDict.js";
 import "./fromMeteor.js";
 import "./client.js";
+import "./types.js";
+import "./diff.js";
+import "./publish.js";

--- a/test/publish.js
+++ b/test/publish.js
@@ -1,0 +1,65 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert";
+import { applyRedis } from "../lib/redis/publish.js";
+
+function makeMockCollection() {
+  const callbacks = new Map();
+  const collection = {
+    collectionName: "tests",
+    callbacks,
+    on(event, cb) {
+      callbacks.set(event, cb);
+      return collection;
+    }
+  };
+  return collection;
+}
+
+describe("applyRedis", () => {
+  it("should publish for deleteOne when _id is 0 (regression: TODO 6)", async () => {
+    // The buggy `if (_id)` truthy check skipped publishing for any deleteOne
+    // whose _id happens to be falsy (0, "", false). The fix uses an
+    // explicit null/undefined comparison so falsy-but-real ids still emit.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.deleteOne.success");
+    await cb({ args: [{}, {}], _id: 0 });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is deleted");
+  });
+
+  it("should publish for updateOne when _id is 0 (regression: TODO 6)", async () => {
+    // Same falsy-id issue on the updateOne path: `if (!_id) return;` would
+    // skip publishing. The fix tightens the guard to null/undefined.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, { $set: { value: 1 } }, {}],
+      _id: 0
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is updated");
+  });
+
+  it("should publish for insertOne when insertedId is 0 (regression: TODO 6)", async () => {
+    // The insert path computed `resultOrig?.insertedId ? [...] : []` — an
+    // _id of 0 was treated as "no insert" and never published.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.insertOne");
+    await cb({
+      args: [{ _id: 0 }, {}],
+      resultOrig: { acknowledged: true, insertedId: 0 },
+      error: undefined
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is inserted");
+  });
+});

--- a/test/redis.js
+++ b/test/redis.js
@@ -531,6 +531,59 @@ describe("Redis Observer", () => {
         "should only subscribe to channels for non-null, non-undefined ids"
       );
     });
+
+    it("should not throw when filter is _id: {} (regression: TODO 4)", () => {
+      // getStrategy picks DEDICATED_CHANNELS because selector._id is truthy.
+      // extractIdsFromSelector then calls getType({}); Object.keys({})[0] is
+      // undefined and undefined.startsWith("$") throws TypeError.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      assert.doesNotThrow(() => {
+        new RedisObserverDriver(
+          collection.find({ _id: {} }, {}),
+          collection,
+          {
+            ordered: false,
+            manager: subscriptionManager,
+            Matcher: Minimongo.Matcher
+          }
+        );
+      });
+    });
+
+    // SKIPPED: regression test for TODO 1 (`strictRelevance` cannot be set to false).
+    // `#strictRelevance` is a private field that nothing reads — the assignment
+    // bug is real (`||` should be `??`) but has no externally observable effect
+    // until either (a) the documented behavior described on `RedisObserverDriverOptions.strictRelevance`
+    // is actually wired through to the projection/filter logic, or (b) the field
+    // is exposed via a public getter for testing. Add a real test once one of
+    // those happens.
+    it.skip("should respect strictRelevance: false (regression: TODO 1)", () => {});
+
+    it("should subscribe to a dedicated channel for literal _id: 0 (regression: TODO 6)", () => {
+      // Two truthy checks erase 0 as a legitimate _id:
+      //   - getStrategy: `if (selector && selector._id)` falls through to DEFAULT for _id: 0.
+      //   - extractIdsFromSelector: `if (selector._id)` skips the value entirely.
+      // Net effect: a doc with _id: 0 never gets a dedicated channel and no
+      // live updates are received for it.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: 0 }, {}),
+        collection,
+        {
+          ordered: false,
+          manager: subscriptionManager,
+          Matcher: Minimongo.Matcher
+        }
+      );
+
+      assert.deepStrictEqual(subscriber.channels, [`${collectionName}::0`]);
+    });
   });
   describe("limit sort processor", () => {
     // insert test cases

--- a/test/redis.js
+++ b/test/redis.js
@@ -308,6 +308,42 @@ describe("Redis Observer", () => {
       await subscriber._queue.flush();
       assert.strictEqual(addedMock.mock.callCount(), 1, "Should not have called added again");
     });
+    it("should not fire removed for unknown ids (regression: TODO 11)", async () => {
+      // The default-strategy REMOVE branch in #processDefaultMessage fires
+      // multiplexer.removed unconditionally, unlike the UPDATE branch and
+      // the dedicated-channels path, which both guard with `await this.#has`.
+      // Downstream observers should never see a `removed` for an id that
+      // was never `added`.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [{ _id: "known" }], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const cursor = collection.find({}, {});
+      const multiplexer = new ObserveMultiplexer({ ordered: false });
+      const subscriber = new RedisObserverDriver(
+        cursor,
+        collection,
+        {
+          ordered: false,
+          manager: subscriptionManager,
+          Matcher: Minimongo.Matcher
+        }
+      );
+
+      multiplexer.addHandleAndSendInitialAdds({ observes() { return false; } });
+      await subscriber.init(multiplexer);
+      await subscriber._queue.flush();
+
+      const removedMock = mock.method(multiplexer, "removed");
+
+      await pubSubManager.emit(collectionName, {
+        [RedisPipe.EVENT]: Events.REMOVE,
+        [RedisPipe.DOC]: { _id: "unknown" },
+        [RedisPipe.UID]: "someone-else"
+      });
+      await subscriber._queue.flush();
+
+      assert.strictEqual(removedMock.mock.callCount(), 0, "should not forward removed for an id the subscriber never added");
+    });
   });
   describe("dedicated channels processor", () => {
     it("Initial added works", async () => {

--- a/test/types.js
+++ b/test/types.js
@@ -1,0 +1,32 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { stringId, fromStringId, naiveClone } from "../lib/types.js";
+
+describe("stringId", () => {
+  it("should produce distinct ids for true and false (regression: TODO 7)", () => {
+    // jsonable() falls through for booleans to Object.entries() which returns
+    // [], so JSON.stringify yields "{}" for any boolean — true and false
+    // collide on the same channel/cache key.
+    assert.notStrictEqual(stringId(true), stringId(false));
+  });
+});
+
+describe("fromStringId", () => {
+  it("should not throw on a JSON-encoded array containing null (regression: TODO 13)", () => {
+    // JSON.parse("[null]") → [null]. jsonToObject hits the array branch and
+    // recurses into jsonToObject(null); accessing null.$type throws TypeError.
+    assert.doesNotThrow(() => fromStringId("[null]"));
+  });
+});
+
+describe("naiveClone", () => {
+  it("should not throw on undefined input (regression: TODO 12)", () => {
+    // observe.ts (lines 132/196) calls cloneIfMutating(cache.get(before))
+    // where cache.get can return undefined under upstream race conditions.
+    // naiveClone(undefined) is JSON.parse(JSON.stringify(undefined)) =
+    // JSON.parse(undefined) which throws SyntaxError. The fix can live
+    // either at the call site (guard before cloning) or here (handle
+    // undefined); either way naiveClone(undefined) should not crash.
+    assert.doesNotThrow(() => naiveClone(undefined));
+  });
+});


### PR DESCRIPTION
These are all bugs that are technically real, but not reachable based on how we currently use it - best to get em all fixed now. 

We don't allow `0` or "" or `false`, `_id`, but they are valid

`#strictRelevance` isn't supported yet - but technically it is unsettable to false

we don't ever use naiveClone in the real world

it would be very hard to receive a removed event for an unobserved doc, and in general we don't care if we get some noops