### PR TITLE
Round 2 bugs

### DIFF
--- a/src/observe.ts
+++ b/src/observe.ts
@@ -123,7 +123,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
           return;
         }
         const addedAtIndex = indices
-          ? before
+          ? (before !== null && before !== undefined)
             ? cache.indexOf(before)
             : cache.size()
           : -1;
@@ -134,7 +134,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
 
         const doc = transform(cloneIfMutating({ _id: id, ...fields }));
 
-        const beforeDoc = before && transform(cloneIfMutating(cache.get(before)));
+        const beforeDoc = (before !== null && before !== undefined) && transform(cloneIfMutating(cache.get(before)));
 
         if (observeCallbacks.addedAt) {
           return observeCallbacks.addedAt(
@@ -180,12 +180,12 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
 
         const from = indices ? cache.indexOf(id) : -1;
         let to = indices
-          ? before
+          ? (before !== null && before !== undefined)
             ? cache.indexOf(before)
             : cache.size()
           : -1;
         cache.movedBefore(id, before);
-        const beforeDoc = before && transform(cloneIfMutating(cache.get(before)));
+        const beforeDoc = (before !== null && before !== undefined) && transform(cloneIfMutating(cache.get(before)));
 
         // When not moving backwards, adjust for the fact that removing the
         // document slides everything back one slot.

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -122,6 +122,11 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         if (suppressed) {
           return;
         }
+        const addedAtIndex = indices
+          ? before
+            ? cache.indexOf(before)
+            : cache.size()
+          : -1;
         cache.addedBefore(id, { _id: id, ...fields }, before);
         if (!(observeCallbacks.addedAt || observeCallbacks.added)) {
           return;
@@ -134,11 +139,7 @@ function observeChangesCallbacksFromObserveCallbacks<T extends { _id: Stringable
         if (observeCallbacks.addedAt) {
           return observeCallbacks.addedAt(
             doc,
-            indices
-              ? before
-                ? cache.indexOf(before)
-                : cache.size()
-              : -1,
+            addedAtIndex,
             beforeDoc
           );
         }

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -58,10 +58,62 @@ export async function handleRemove(
   }
 }
 
+// Returns the union of top-level field names affected by `mutator`, or
+// `undefined` if the affected set is not statically knowable (replacement
+// updates and pipelines containing $replaceRoot/$replaceWith). Subscribers
+// treat absent FIELDS as "always fetch".
+export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefined {
+  if (mutator == null || typeof mutator !== "object") return undefined;
+
+  if (Array.isArray(mutator)) {
+    const fields = new Set<string>();
+    for (const stage of mutator) {
+      if (!stage || typeof stage !== "object" || Array.isArray(stage)) continue;
+      for (const [op, operand] of Object.entries(stage)) {
+        if (op === "$replaceRoot" || op === "$replaceWith") return undefined;
+        if (op === "$unset") {
+          if (typeof operand === "string") {
+            fields.add(operand.split(".")[0]);
+          }
+          else if (Array.isArray(operand)) {
+            for (const path of operand) {
+              if (typeof path === "string") fields.add(path.split(".")[0]);
+            }
+          }
+          continue;
+        }
+        if (op === "$set" || op === "$addFields" || op === "$project") {
+          if (operand && typeof operand === "object" && !Array.isArray(operand)) {
+            for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
+          }
+          continue;
+        }
+        // Unknown stage — be safe. If we ever hit this with a collection that still uses the old redis-oplog code, we'll have a problem
+        // this is OK - it's currently not used and we have no immediate plans to use it
+        return undefined;
+      }
+    }
+    return [...fields];
+  }
+
+  const entries = Object.entries(mutator);
+  if (entries.length === 0) return [];
+  // Replacement form: any non-$ top-level key means the whole doc is being
+  // replaced with that object, and removed fields aren't enumerable.
+  if (entries.some(([k]) => !k.startsWith("$"))) return undefined;
+
+  const fields = new Set<string>();
+  for (const [, operand] of entries) {
+    if (!operand || typeof operand !== "object" || Array.isArray(operand)) continue;
+    for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
+  }
+  return [...fields];
+}
+
 export async function handleUpdate(
   defaultChannel: string,
   _ids: Stringable[],
-  fields: string[],
+  fields: string[] | undefined,
   options: RedisOptions,
   publishOptions: PublishOptions
 ) {
@@ -72,10 +124,12 @@ export async function handleUpdate(
         const event: RedisUpdate<{ _id: Stringable }> = {
           [RedisPipe.EVENT]: Events.UPDATE,
           [RedisPipe.DOC]: { _id },
-          // @ts-expect-error we're going to trust that fields is the top level keys
-          [RedisPipe.FIELDS]: fields,
           [RedisPipe.UID]: publishOptions.uid
         };
+        if (fields !== undefined) {
+          // @ts-expect-error we're going to trust that fields is the top level keys
+          event[RedisPipe.FIELDS] = fields;
+        }
         try {
           await publishOptions.emit(channel, event, options);
         }
@@ -211,7 +265,7 @@ export function applyRedis<
     if (_id === null || _id === undefined) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
     await handleUpdate(defaultChannel, [_id as unknown as Stringable], fields, options as RedisOptions || {}, publishOptions);
   }, { tags: ["redis"], includeId: true });
 
@@ -219,7 +273,7 @@ export function applyRedis<
     args: [, mutator, options],
     _ids
   }) => {
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
     // TODO: what about partial deletion?
     await handleUpdate(defaultChannel, _ids as unknown as Stringable[], fields, options as RedisOptions || {}, publishOptions);
   }, { tags: ["redis"], includeIds: true });
@@ -246,7 +300,7 @@ export function applyRedis<
     if (!result) { // it's entirely possible for updateOne to not find a document to delete
       return;
     }
-    const fields = Array.from(new Set(Object.values(mutator).flatMap($mutator => Object.keys($mutator).map(key => key.split(".")[0]))));
+    const fields = topLevelFieldsFromMutator(mutator);
 
     const _id = idFromMaybeResult(result);
     if (_id === null || _id === undefined) {

--- a/src/redis/publish.ts
+++ b/src/redis/publish.ts
@@ -60,7 +60,7 @@ export async function handleRemove(
 
 // Returns the union of top-level field names affected by `mutator`, or
 // `undefined` if the affected set is not statically knowable (replacement
-// updates and pipelines containing $replaceRoot/$replaceWith). Subscribers
+// updates and pipelines containing $project/$replaceRoot/$replaceWith). Subscribers
 // treat absent FIELDS as "always fetch".
 export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefined {
   if (mutator == null || typeof mutator !== "object") return undefined;
@@ -70,7 +70,7 @@ export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefine
     for (const stage of mutator) {
       if (!stage || typeof stage !== "object" || Array.isArray(stage)) continue;
       for (const [op, operand] of Object.entries(stage)) {
-        if (op === "$replaceRoot" || op === "$replaceWith") return undefined;
+        if (op === "$project" || op === "$replaceRoot" || op === "$replaceWith") return undefined;
         if (op === "$unset") {
           if (typeof operand === "string") {
             fields.add(operand.split(".")[0]);
@@ -82,7 +82,7 @@ export function topLevelFieldsFromMutator(mutator: unknown): string[] | undefine
           }
           continue;
         }
-        if (op === "$set" || op === "$addFields" || op === "$project") {
+        if (op === "$set" || op === "$addFields") {
           if (operand && typeof operand === "object" && !Array.isArray(operand)) {
             for (const key of Object.keys(operand)) fields.add(key.split(".")[0]);
           }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -76,8 +76,6 @@ export class RedisObserverDriver<
   #sortProjectionFn: (projection: Document) => SortT;
   #transform: (doc: any) => ET;
 
-  // down the road, we might merge sortDocs and docs - currently docs is totally unused and we rely on the multiplexer to track the current document
-  #docs: OrderedDict<T["_id"], SortT & T> | undefined;
   // #sortDocs contains the document ID + the fields necessary to evaluate the sort.
   #sortDocs: OrderedDict<T["_id"], SortT> | undefined;
   #strictRelevance: boolean;
@@ -221,9 +219,6 @@ export class RedisObserverDriver<
   }
 
   async #has(id: Stringable): Promise<boolean> {
-    if (this.#docs) {
-      return this.#docs.has(id);
-    }
     if (this.#multiplexer) {
       return this.#multiplexer.has(id);
     }
@@ -231,14 +226,6 @@ export class RedisObserverDriver<
   }
 
   async #get(id: Stringable): Promise<ET | undefined> {
-    if (this.#docs) {
-      const doc = this.#docs.get(id);
-      if (!doc) {
-        return;
-      }
-      const { _id, ...docMinusId } = this.#projectionFn(doc);
-      return docMinusId as unknown as ET;
-    }
     if (this.#multiplexer) {
       const multiDoc = await this.#multiplexer.get(id);
       if (!multiDoc) {
@@ -261,9 +248,6 @@ export class RedisObserverDriver<
     return this.#transform(rest);
   }
   async #size(): Promise<number> {
-    if (this.#docs) {
-      return this.#docs.size;
-    }
     if (!this.#multiplexer) {
       throw new Error("Neither docs nor multiplexer");
     }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -120,8 +120,12 @@ export class RedisObserverDriver<
     this.#channels = this.#getChannels(channelsFromOptions);
     this.#strictRelevance = options.strictRelevance || true;
     if (this.#cursor.cursorDescription.options.sort) {
-      this.#comparator = new options.Sorter(this.#cursor.cursorDescription.options.sort).getComparator();
-      this.#sortProjection = Object.fromEntries(Object.entries(this.#cursor.cursorDescription.options.sort).map(([key]) => [key, 1])) as NestedProjectionOfTSchema<SortT>
+      const rawSort = this.#cursor.cursorDescription.options.sort;
+      const sortObject = Array.isArray(rawSort)
+        ? Object.fromEntries(rawSort)
+        : rawSort;
+      this.#comparator = new options.Sorter(sortObject).getComparator();
+      this.#sortProjection = Object.fromEntries(Object.keys(sortObject).map((key) => [key, 1])) as NestedProjectionOfTSchema<SortT>
       // @ts-expect-error
       this.#sortProjectionFn = options.compileProjection(this.#sortProjection) as (doc: T & SortT & FilterT) => SortT;
       this.#combinedProjection = unionOfProjections<T & SortT>([
@@ -369,7 +373,7 @@ export class RedisObserverDriver<
             {
               projection: unionOfProjections([
                 this.#cursor.cursorDescription.options.projection as NestedProjectionOfTSchema<T>,
-                Object.fromEntries(Object.entries(this.#cursor.cursorDescription.options.sort || {}).map(([key]) => [key, 1])) as NestedProjectionOfTSchema<T>,
+                (this.#sortProjection || {}) as NestedProjectionOfTSchema<T>,
                 this.#matcher._path
               ])
             }

--- a/src/redis/subscriber.ts
+++ b/src/redis/subscriber.ts
@@ -370,13 +370,7 @@ export class RedisObserverDriver<
           const actualDoc = id === newCommer._id ? newCommer as T & SortT : await this.#collection.findOne(
             // @ts-expect-error
             { _id: id },
-            {
-              projection: unionOfProjections([
-                this.#cursor.cursorDescription.options.projection as NestedProjectionOfTSchema<T>,
-                (this.#sortProjection || {}) as NestedProjectionOfTSchema<T>,
-                this.#matcher._path
-              ])
-            }
+            { projection: this.completeProjection }
           ) as T & SortT;
           if (!actualDoc) {
             return;

--- a/src/redis/types.ts
+++ b/src/redis/types.ts
@@ -20,7 +20,7 @@ export type RedisInsert<T extends { _id: Stringable }> = {
 export type RedisUpdate<T extends { _id: Stringable }> = {
   [RedisPipe.EVENT]: typeof Events.UPDATE,
   [RedisPipe.DOC]: T,
-  [RedisPipe.FIELDS]: (keyof T & string)[],
+  [RedisPipe.FIELDS]?: (keyof T & string)[],
   [RedisPipe.UID]: Stringable
 }
 

--- a/src/redis/utils.ts
+++ b/src/redis/utils.ts
@@ -33,6 +33,9 @@ export function extractIdsFromSelector<T extends { _id: Stringable }>(selector: 
     else if (selector._id instanceof RegExp || (selector._id as BSONRegExp)._bsontype === "BSONRegExp") {
       // do nothing
     }
+    else if (selector._id instanceof Date) {
+      ids.add(selector._id);
+    }
     else {
       const idField: ObjectId | FilterOperators<Stringable> = selector._id as ObjectId | FilterOperators<Stringable>;
       const type = getType(idField);

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -1,8 +1,19 @@
 import { Stringable, fromStringId, stringId } from "./types.js";
 
 export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, T> {
-  constructor(entries?: [ID, T][]) {
-    super(entries?.map(([key, value]) => [stringId(key), value]));
+  constructor(entries?: Iterable<readonly [ID, T]> | null) {
+    // the else is more correct, but 99.9% of the time we'll be passing in an array, and I don't want to risk changing behaviour to satisfy typescript
+    if (entries && Array.isArray(entries)) {
+      super((entries as [ID, T][])?.map(([key, value]) => [stringId(key), value]));
+    }
+    else {
+      super();
+      if (entries) {
+        for (const [key, value] of entries) {
+          super.set(stringId(key), value);
+        }
+      }
+    }
   }
 
   delete(key: ID | string): boolean {
@@ -22,7 +33,7 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
     return this;
   }
 
-  [Symbol.species]() {
+  static get [Symbol.species]() {
     return StringableIdMap;
   }
 

--- a/src/stringableIdMap.ts
+++ b/src/stringableIdMap.ts
@@ -33,10 +33,6 @@ export class StringableIdMap<ID extends Stringable, T> extends Map<ID | string, 
     return this;
   }
 
-  static get [Symbol.species]() {
-    return StringableIdMap;
-  }
-
   keys(): MapIterator<ID | string> {
     const iterator = super.keys();
     // @ts-ignore - vscode doesn't mind this, but tsc does

--- a/test/observe.js
+++ b/test/observe.js
@@ -395,6 +395,54 @@ describe("unordered observe", () => {
 });
 
 describe("ordered observe", () => {
+  it("addedAt receives the actual index of the inserted document", async () => {
+    const collection = new FakeCollection([{ _id: "test" }]);
+    const cursor = collection.find({});
+    const addedMock = mock.fn();
+    const handle = await observe(
+      cursor,
+      collection,
+      { addedAt: addedMock },
+      { ordered: true, pollingInterval: 5 }
+    );
+
+    assert.strictEqual(addedMock.mock.callCount(), 1, "should have seen the initial add");
+    assert.strictEqual(
+      addedMock.mock.calls[0].arguments[1],
+      0,
+      "addedAt should report index 0 for the first document"
+    );
+    handle.stop();
+  });
+  it("addedAt receives the actual index when a document is inserted before another", async () => {
+    const collection = new FakeCollection([{ _id: "a", field: 1 }]);
+    const cursor = collection.find({}, { sort: { field: 1 } });
+    const addedMock = mock.fn();
+    const handle = await observe(
+      cursor,
+      collection,
+      { addedAt: addedMock },
+      { ordered: true, pollingInterval: 5 }
+    );
+
+    assert.strictEqual(addedMock.mock.callCount(), 1, "should have seen the initial add");
+
+    cursor._data.unshift({ _id: "b", field: 0 });
+    await setTimeout(10);
+
+    assert.strictEqual(addedMock.mock.callCount(), 2, "should have seen the new add");
+    assert.strictEqual(
+      addedMock.mock.calls[1].arguments[0]._id,
+      "b",
+      "second addedAt call should be for the new doc"
+    );
+    assert.strictEqual(
+      addedMock.mock.calls[1].arguments[1],
+      0,
+      "addedAt should report index 0 for a doc inserted before all existing docs"
+    );
+    handle.stop();
+  });
   it("additional addedBefores are received", async () => {
     const data = [{ _id: "test" }, { _id: "test2" }];
     const collection = new FakeCollection(data);

--- a/test/publish.js
+++ b/test/publish.js
@@ -1,6 +1,7 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
 import { applyRedis } from "../lib/redis/publish.js";
+import { RedisPipe } from "../lib/redis/constants.js";
 
 function makeMockCollection() {
   const callbacks = new Map();
@@ -44,6 +45,69 @@ describe("applyRedis", () => {
     });
 
     assert.ok(emitMock.mock.callCount() > 0, "emit should fire when _id: 0 is updated");
+  });
+
+  it("should compute FIELDS from a pipeline-form mutator (regression: TODO 5)", async () => {
+    // Pipeline-form update: an array of stages. Today's parser does
+    // `Object.values(mutator).flatMap($m => Object.keys($m))` which on an
+    // array yields the *operator names* (e.g., '$set'), not the affected
+    // fields. The subscriber-side fetch filter then sees ['$set'] which
+    // never matches a projection — the change is silently dropped.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $set: { a: 1 } }, { $unset: ["b"] }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should publish at least one message");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.deepStrictEqual(
+      [...(message[RedisPipe.FIELDS] || [])].sort(),
+      ["a", "b"],
+      "FIELDS should be the union of LHS keys across pipeline stages"
+    );
+  });
+
+  it("should omit FIELDS for a pipeline with $replaceWith (regression: TODO 5)", async () => {
+    // $replaceWith / $replaceRoot replaces the doc with an arbitrary
+    // expression. The affected field set is not statically knowable, so
+    // emit no FIELDS — the consumer (shouldFetchForFields) treats absent
+    // fields as "always fetch", which is the safe behavior.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $replaceWith: { a: "$x", b: 2 } }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should still publish");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.strictEqual(
+      message[RedisPipe.FIELDS],
+      undefined,
+      "FIELDS should be absent so subscribers re-fetch"
+    );
+  });
+
+  it("should not crash when a mutator operand is null (regression: TODO 5)", async () => {
+    // Defensive: an operator whose value is null (e.g., {$set: null}) used
+    // to throw `Object.keys(null)` and propagate up the hook chain.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await assert.doesNotReject(
+      cb({ args: [{}, { $set: null }, {}], _id: "x" }),
+      "publisher should not throw on a null operator value"
+    );
   });
 
   it("should publish for insertOne when insertedId is 0 (regression: TODO 6)", async () => {

--- a/test/publish.js
+++ b/test/publish.js
@@ -96,6 +96,28 @@ describe("applyRedis", () => {
     );
   });
 
+  it("should omit FIELDS for a pipeline with $project", async () => {
+    // Inclusion-form $project names the retained fields, not every removed
+    // field. The affected field set is therefore not statically knowable.
+    const collection = makeMockCollection();
+    const emitMock = mock.fn(async () => {});
+    applyRedis(collection, { uid: "u", emit: emitMock });
+
+    const cb = collection.callbacks.get("after.updateOne.success");
+    await cb({
+      args: [{}, [{ $project: { kept: 1 } }], {}],
+      _id: "x"
+    });
+
+    assert.ok(emitMock.mock.callCount() > 0, "should still publish");
+    const message = emitMock.mock.calls[0].arguments[1];
+    assert.strictEqual(
+      message[RedisPipe.FIELDS],
+      undefined,
+      "FIELDS should be absent so subscribers re-fetch"
+    );
+  });
+
   it("should not crash when a mutator operand is null (regression: TODO 5)", async () => {
     // Defensive: an operator whose value is null (e.g., {$set: null}) used
     // to throw `Object.keys(null)` and propagate up the hook chain.

--- a/test/redis.js
+++ b/test/redis.js
@@ -851,6 +851,43 @@ describe("Redis Observer", () => {
     // those happens.
     it.skip("should respect strictRelevance: false (regression: TODO 1)", () => {});
 
+    it("should subscribe to a dedicated channel for a Date _id (regression: TODO 11)", () => {
+      // getType(new Date()) returns EMPTY because Object.keys(date) is [],
+      // so the Date is silently dropped from extractIdsFromSelector and
+      // the subscriber registers no per-id channel.
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const date = new Date(0);
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: date }, {}),
+        collection,
+        { ordered: false, manager: subscriptionManager, Matcher: Minimongo.Matcher }
+      );
+      assert.deepStrictEqual(
+        subscriber.channels,
+        [`${collectionName}::${stringId(date)}`],
+        "should produce a per-id channel keyed on the stringified Date"
+      );
+    });
+
+    it("should subscribe to a dedicated channel for a Date _id under $eq (regression: TODO 11)", () => {
+      const pubSubManager = new TestPubSubManager();
+      const collection = new CollectionThatEmits(collectionName, [], pubSubManager);
+      const subscriptionManager = new SubscriptionManager(pubSubManager);
+      const date = new Date(0);
+      const subscriber = new RedisObserverDriver(
+        collection.find({ _id: { $eq: date } }, {}),
+        collection,
+        { ordered: false, manager: subscriptionManager, Matcher: Minimongo.Matcher }
+      );
+      assert.deepStrictEqual(
+        subscriber.channels,
+        [`${collectionName}::${stringId(date)}`],
+        "should produce a per-id channel for { $eq: Date }"
+      );
+    });
+
     it("should subscribe to a dedicated channel for literal _id: 0 (regression: TODO 6)", () => {
       // Two truthy checks erase 0 as a legitimate _id:
       //   - getStrategy: `if (selector && selector._id)` falls through to DEFAULT for _id: 0.

--- a/test/redis.js
+++ b/test/redis.js
@@ -875,6 +875,25 @@ describe("Redis Observer", () => {
     });
   });
   describe("limit sort processor", () => {
+    it("should not throw when requery runs with no filter (regression: TODO 4)", async () => {
+      // No filter → no matcher → #requery accessing this.#matcher._path
+      // would throw TypeError on the first cross-window insert with skip.
+      // The throw is swallowed by the queue's default error handler
+      // (console.warn), so the failure surfaces as a missing addedBefore.
+      const { collection, multiplexer, subscriber } = await setup(
+        undefined,
+        { sort: { number: 1 }, skip: 1 },
+        [{ _id: "1", number: 1 }]
+      );
+      const addedBeforeMock = mock.method(multiplexer, "addedBefore");
+      await collection.insertOne({ _id: "2", number: 0 });
+      await subscriber._queue.flush();
+      assert.strictEqual(
+        addedBeforeMock.mock.callCount(),
+        1,
+        "should have called addedBefore for the doc that became visible after skip"
+      );
+    });
     it("should accept array-form sort and produce a sort projection by field name (regression: TODO 3)", async () => {
       const { subscriber } = await setup(
         {},

--- a/test/redis.js
+++ b/test/redis.js
@@ -875,6 +875,18 @@ describe("Redis Observer", () => {
     });
   });
   describe("limit sort processor", () => {
+    it("should accept array-form sort and produce a sort projection by field name (regression: TODO 3)", async () => {
+      const { subscriber } = await setup(
+        {},
+        { sort: [["number", 1]], projection: { thing: 1 } },
+        [{ _id: "1", number: 1, thing: "a" }]
+      );
+      assert.deepStrictEqual(
+        subscriber.completeProjection,
+        { thing: 1, number: 1 },
+        "completeProjection should be keyed by field name, not array index"
+      );
+    });
     // insert test cases
     it("should call addedBefore when inserting a document AFTER the set, without a limit", async () => {
       const {


### PR DESCRIPTION
### `observe.ts` — `addedAt` index is off-by-one (might matter)
**Symptom:** the `atIndex` argument passed to `addedAt` is always `(actual_index + 1)`. `cache.size()` and `cache.indexOf(before)` are computed *after* `cache.addedBefore`, so both reflect the post-insert state.

### `subscriber.ts:124` — sort-as-array silently breaks projection (unlikely to matter)
The `sort` type allows `[string, 1|-1][]`. With an array sort, `Object.entries(sort)` yields `["0", ["field", 1]]`, so the sort projection becomes `{ "0": 1, "1": 1 }` instead of `{ field: 1 }`. `combinedProjection` and `cursor.project(...)` degrade silently.

### `subscriber.ts:373` — `this.#matcher._path` crashes when no filter (will matter - sort + no filter + changes would break)
The matcher is only constructed when `cursor.cursorDescription.filter` is set (line 143). A LIMIT_SORT cursor with sort+limit but no filter throws `TypeError: Cannot read properties of undefined (reading '_path')` on the first requery. `_path` is also private API of Matcher — brittle.

### `observe.ts` — falsy treatment of `before === 0` / `""` (unlikely to matter - these fall into the same "thanks typescript" category)
`before ? cache.indexOf(before) : cache.size()` and
`before && transform(cache.get(before))` collapse legitimate IDs of `0` or
`""` to "no before". `Stringable` allows `number | boolean | string | …`,
so this is reachable.

### `utils.ts:34` — Date `_id` falls into "EMPTY" branch (unlikely to matter)
`Object.keys(new Date())` is `[]`, so a Date `_id` is dropped from
`extractIdsFromSelector`. Subscribers with Date IDs silently regress to
DEFAULT-strategy semantics.

### `stringableIdMap.ts:25` — `Symbol.species` declared as a method (extremely unlikely to matter)

### `subscriber.ts` — `#docs` is declared but never assigned (dead code cleanup)
`#docs: OrderedDict<...> | undefined` — never assigned anywhere. Every `if (this.#docs)` branch (in `#has`, `#get`, `#size`) is dead. Misleading to readers.

### `publish.ts` — mutator parsing crashes on pipeline
Assumes `mutator` is `{ $set: {...}, $inc: {...} }`. Other valid Mongo inputs break:
- Pipeline-form update (`[ { $set: {...} } ]`) — `Object.values(arr)` works
  but `key.split` would receive numeric-string keys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core observe/Redis reactivity paths (ordered indexing, subscriber projections, and published UPDATE metadata), so regressions could silently drop or misorder live updates despite added tests.
> 
> **Overview**
> Fixes several correctness issues in ordered observation and Redis-based live updates.
> 
> In `observe.ts`, `addedAt` now reports the pre-insert index (and treats `before` values like `0`/`""` as valid), eliminating off-by-one and falsy-ID bugs; new tests assert correct indices.
> 
> In Redis publish/subscribe, UPDATE messages now compute top-level changed fields via `topLevelFieldsFromMutator` (including pipeline-form updates) and omit `FIELDS` when the impacted field set can’t be determined; `RedisUpdate` is updated to make `FIELDS` optional. The subscriber also now supports array-form `sort`, avoids requery crashes when there is no matcher by using `completeProjection`, and removes unused `#docs` branches. Additional regression tests cover pipeline mutators, Date `_id` channel extraction, and sort/requery edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748e4371bede9bd839a9430ef2230a80cb2d0c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->